### PR TITLE
Remove key from index. Minor bug fix.

### DIFF
--- a/store/index/buckets.go
+++ b/store/index/buckets.go
@@ -16,7 +16,7 @@ func NewBuckets(indexSizeBits uint8) (Buckets, error) {
 	if indexSizeBits > 32 {
 		return nil, types.ErrIndexTooLarge
 	}
-	return make(Buckets, 1<<indexSizeBits, 1<<indexSizeBits), nil
+	return make(Buckets, 1<<indexSizeBits), nil
 }
 
 // Put updates a bucket value
@@ -47,7 +47,7 @@ func NewSizeBuckets(indexSizeBits uint8) (SizeBuckets, error) {
 	if indexSizeBits > 32 {
 		return nil, types.ErrIndexTooLarge
 	}
-	return make(SizeBuckets, 1<<indexSizeBits, 1<<indexSizeBits), nil
+	return make(SizeBuckets, 1<<indexSizeBits), nil
 }
 
 // Put updates a bucket value

--- a/store/index/buckets_test.go
+++ b/store/index/buckets_test.go
@@ -43,6 +43,7 @@ func TestPutError(t *testing.T) {
 func TestGet(t *testing.T) {
 	var bucketBits uint8 = 3
 	buckets, err := index.NewBuckets(bucketBits)
+	require.NoError(t, err)
 	value, err := buckets.Get(3)
 	require.NoError(t, err)
 	require.Equal(t, types.Position(0), value)

--- a/store/index/index.go
+++ b/store/index/index.go
@@ -154,6 +154,9 @@ func OpenIndex(path string, primary primary.PrimaryStorage, indexSizeBits uint8)
 func scanIndex(path string, indexSizeBits uint8) (Buckets, SizeBuckets, error) {
 	// this is a single sequential read across the whole index
 	file, err := openFileForScan(path)
+	if err != nil {
+		return nil, nil, err
+	}
 	defer func() {
 		_ = file.Close()
 	}()
@@ -176,7 +179,7 @@ func scanIndex(path string, indexSizeBits uint8) (Buckets, SizeBuckets, error) {
 	iter := NewIndexIter(buffered, types.Position(bytesRead))
 	for {
 		data, pos, err, done := iter.Next()
-		if done == true {
+		if done {
 			break
 		}
 		if err == io.EOF {
@@ -369,21 +372,21 @@ func (i *Index) Remove(key []byte) (bool, error) {
 	if records == nil {
 		// No records in index. Nothing to remove.
 		return false, nil
-	} else {
-		// Read the record list to find the key and position
-		r := records.GetRecord(indexKey)
-		if r == nil {
-			// The record doesn't exist. Nothing to remove
-			return false, nil
-		}
-
-		// Remove key from record
-		newData = records.PutKeys([]KeyPositionPair{}, r.Pos, r.NextPos())
-		// NOTE: We are removing the key without changing any keys. If we want
-		// to optimize for storage we need to check the keys with the same prefix
-		// and see if any of them can be shortened. This process will be similar
-		// to finding where to put a new key.
 	}
+
+	// Read the record list to find the key and position
+	r := records.GetRecord(indexKey)
+	if r == nil {
+		// The record doesn't exist. Nothing to remove
+		return false, nil
+	}
+
+	// Remove key from record
+	newData = records.PutKeys([]KeyPositionPair{}, r.Pos, r.NextPos())
+	// NOTE: We are removing the key without changing any keys. If we want
+	// to optimize for storage we need to check the keys with the same prefix
+	// and see if any of them can be shortened. This process will be similar
+	// to finding where to put a new key.
 
 	i.outstandingWork += types.Work(len(newData) + BucketPrefixSize + SizePrefixSize)
 	i.nextPool[bucket] = newData

--- a/store/index/index.go
+++ b/store/index/index.go
@@ -345,6 +345,51 @@ func (i *Index) Update(key []byte, location types.Block) error {
 	return nil
 }
 
+// Remove a key from index
+func (i *Index) Remove(key []byte) (bool, error) {
+	// Get record list and bucket index
+	bucket, err := i.getBucketIndex(key)
+	if err != nil {
+		return false, err
+	}
+	i.bucketLk.Lock()
+	defer i.bucketLk.Unlock()
+	records, err := i.getRecordsFromBucket(bucket)
+	if err != nil {
+		return false, err
+	}
+
+	// The key doesn't need the prefix that was used to find the right bucket. For simplicty
+	// only full bytes are trimmed off.
+	indexKey := StripBucketPrefix(key, i.sizeBits)
+
+	var newData []byte
+	// If no records stored in that bucket yet it means there is no key
+	// to be removed.
+	if records == nil {
+		// No records in index. Nothing to remove.
+		return false, nil
+	} else {
+		// Read the record list to find the key and position
+		r := records.GetRecord(indexKey)
+		if r == nil {
+			// The record doesn't exist. Nothing to remove
+			return false, nil
+		}
+
+		// Remove key from record
+		newData = records.PutKeys([]KeyPositionPair{}, r.Pos, r.NextPos())
+		// NOTE: We are removing the key without changing any keys. If we want
+		// to optimize for storage we need to check the keys with the same prefix
+		// and see if any of them can be shortened. This process will be similar
+		// to finding where to put a new key.
+	}
+
+	i.outstandingWork += types.Work(len(newData) + BucketPrefixSize + SizePrefixSize)
+	i.nextPool[bucket] = newData
+	return true, nil
+}
+
 func (i *Index) getBucketIndex(key []byte) (BucketIndex, error) {
 	if len(key) < 4 {
 		return 0, types.ErrKeyTooShort

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -138,8 +138,65 @@ func TestIndexPutSingleKey(t *testing.T) {
 	require.Equal(t,
 		len(record.Key),
 		1,
-		"Key is trimmed to one byteas it's the only key in the record list",
+		"Key is trimmed to one bytes it's the only key in the record list",
 	)
+}
+
+// This test is about making sure that we remove the record for a key successfully
+
+func TestIndexRemoveKey(t *testing.T) {
+	k1 := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	k2 := []byte{1, 2, 3, 55, 5, 6, 7, 8, 9, 10}
+	b1 := types.Block{Offset: 0, Size: 1}
+	b2 := types.Block{Offset: 1, Size: 2}
+
+	const bucketBits uint8 = 24
+	primaryStorage := inmemory.NewInmemory([][2][]byte{})
+	tempDir, err := ioutil.TempDir("", "sth")
+	require.NoError(t, err)
+	indexPath := filepath.Join(tempDir, "storethehash.index")
+	i, err := index.OpenIndex(indexPath, primaryStorage, bucketBits)
+	require.NoError(t, err)
+	// Put key 1
+	err = i.Put(k1, b1)
+	require.NoError(t, err)
+	// Put key 2
+	err = i.Put(k2, b2)
+	require.NoError(t, err)
+	// Remove key
+	removed, err := i.Remove(k1)
+	require.NoError(t, err)
+	require.True(t, removed)
+
+	_, found, err := i.Get(k1)
+	require.NoError(t, err)
+	require.False(t, found)
+
+	secondKeyBlock, found, err := i.Get(k2)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, secondKeyBlock, b2)
+
+	// Trying to remove a non-existing key
+	removed, err = i.Remove([]byte{1, 2, 3, 78, 5, 6, 7, 8, 9, 10})
+	require.NoError(t, err)
+	require.False(t, removed)
+
+	// Flush and check if it holds
+	_, err = i.Flush()
+	require.NoError(t, err)
+	err = i.Sync()
+	require.NoError(t, err)
+
+	_, found, err = i.Get(k1)
+	require.NoError(t, err)
+	require.False(t, found)
+
+	secondKeyBlock, found, err = i.Get(k2)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, secondKeyBlock, b2)
+
 }
 
 // This test is about making sure that a new key that doesn't share any prefix with other keys

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -163,6 +163,7 @@ func TestIndexRemoveKey(t *testing.T) {
 	// Put key 2
 	err = i.Put(k2, b2)
 	require.NoError(t, err)
+
 	// Remove key
 	removed, err := i.Remove(k1)
 	require.NoError(t, err)
@@ -176,6 +177,11 @@ func TestIndexRemoveKey(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Equal(t, secondKeyBlock, b2)
+
+	// Removing the same key again
+	removed, err = i.Remove(k1)
+	require.NoError(t, err)
+	require.False(t, removed)
 
 	// Trying to remove a non-existing key
 	removed, err = i.Remove([]byte{1, 2, 3, 78, 5, 6, 7, 8, 9, 10})
@@ -196,6 +202,16 @@ func TestIndexRemoveKey(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Equal(t, secondKeyBlock, b2)
+
+	// Removing all keys from storage
+	removed, err = i.Remove(k2)
+	require.NoError(t, err)
+	require.True(t, removed)
+
+	// Removing over empty record
+	removed, err = i.Remove(k2)
+	require.NoError(t, err)
+	require.False(t, removed)
 
 }
 

--- a/store/index/recordlist_test.go
+++ b/store/index/recordlist_test.go
@@ -85,7 +85,7 @@ func TestRecordListFindKeyPosition(t *testing.T) {
 	require.False(t, hasPrev)
 
 	// Between two keys with same prefix, but first one being shorter
-	pos, prevRecord, hasPrev = records.FindKeyPosition([]byte("ab"))
+	pos, prevRecord, _ = records.FindKeyPosition([]byte("ab"))
 	require.Equal(t, pos, 14)
 	require.Equal(t, prevRecord.Key, []byte("a"))
 
@@ -96,13 +96,13 @@ func TestRecordListFindKeyPosition(t *testing.T) {
 
 	// Between two keys with both having a different prefix and the input key having a
 	// different length
-	pos, prevRecord, hasPrev = records.FindKeyPosition([]byte("cabefg"))
+	pos, prevRecord, _ = records.FindKeyPosition([]byte("cabefg"))
 	require.Equal(t, pos, 43)
 	require.Equal(t, prevRecord.Key, []byte("b"))
 
 	// Between two keys with both having a different prefix (with one character in common),
 	// all keys having the same length
-	pos, prevRecord, hasPrev = records.FindKeyPosition([]byte("dg"))
+	pos, prevRecord, _ = records.FindKeyPosition([]byte("dg"))
 	require.Equal(t, pos, 72)
 	require.Equal(t, prevRecord.Key, []byte("de"))
 

--- a/store/store.go
+++ b/store/store.go
@@ -287,11 +287,9 @@ func (s *Store) Remove(key []byte) (bool, error) {
 		return false, err
 	}
 
-	// Compare keys
-	cmpKey := bytes.Equal(indexKey, storedKey)
-	// If they are not equal, it means that the key doesn't exist and
+	// If keys are not equal, it means that the key doesn't exist and
 	// there's nothing to remove.
-	if !cmpKey {
+	if !bytes.Equal(indexKey, storedKey) {
 		return false, nil
 	}
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1,12 +1,16 @@
 package store_test
 
 import (
+	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	store "github.com/ipld/go-storethehash/store"
+	"github.com/ipld/go-storethehash/store/freelist"
 	cidprimary "github.com/ipld/go-storethehash/store/primary/cid"
 	"github.com/ipld/go-storethehash/store/testutil"
 	"github.com/ipld/go-storethehash/store/types"
@@ -17,11 +21,9 @@ const defaultIndexSizeBits = uint8(24)
 const defaultBurstRate = 4 * 1024 * 1024
 const defaultSyncInterval = time.Second
 
-func initStore(t *testing.T) (*store.Store, error) {
-	tempDir, err := ioutil.TempDir("", "sth")
-	require.NoError(t, err)
-	indexPath := filepath.Join(tempDir, "storethehash.index")
-	dataPath := filepath.Join(tempDir, "storethehash.data")
+func initStore(t *testing.T, dir string) (*store.Store, error) {
+	indexPath := filepath.Join(dir, "storethehash.index")
+	dataPath := filepath.Join(dir, "storethehash.data")
 	primary, err := cidprimary.OpenCIDPrimary(dataPath)
 	if err != nil {
 		return nil, err
@@ -30,7 +32,9 @@ func initStore(t *testing.T) (*store.Store, error) {
 }
 
 func TestUpdate(t *testing.T) {
-	s, err := initStore(t)
+	tempDir, err := ioutil.TempDir("", "sth")
+	require.NoError(t, err)
+	s, err := initStore(t, tempDir)
 	require.NoError(t, err)
 	blks := testutil.GenerateBlocksOfSize(2, 100)
 
@@ -58,4 +62,67 @@ func TestUpdate(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, value, blks[1].RawData())
 
+	s.Flush()
+
+	// Start iterator
+	flPath := filepath.Join(tempDir, "storethehash.index.free")
+	file, err := os.Open(flPath)
+	require.NoError(t, err)
+	iter := freelist.NewFreeListIter(file)
+	// Check freelist for the only update. Should be the first position
+	blk, err := iter.Next()
+	require.Equal(t, blk.Offset, types.Position(0))
+	require.NoError(t, err)
+	// Check that is the last
+	_, err = iter.Next()
+	require.EqualError(t, err, io.EOF.Error())
+}
+
+func TestRemove(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "sth")
+	require.NoError(t, err)
+	s, err := initStore(t, tempDir)
+	require.NoError(t, err)
+	blks := testutil.GenerateBlocksOfSize(2, 100)
+
+	t.Logf("Putting blocks")
+	err = s.Put(blks[0].Cid().Bytes(), blks[0].RawData())
+	require.NoError(t, err)
+	err = s.Put(blks[1].Cid().Bytes(), blks[1].RawData())
+	require.NoError(t, err)
+
+	t.Logf("Removing the first block")
+	removed, err := s.Remove(blks[0].Cid().Bytes())
+	require.NoError(t, err)
+	require.True(t, removed)
+
+	t.Logf("Checking if the block has been removed successfully")
+	value, found, err := s.Get(blks[1].Cid().Bytes())
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, value, blks[1].RawData())
+	_, found, err = s.Get(blks[0].Cid().Bytes())
+	require.NoError(t, err)
+	require.False(t, found)
+
+	t.Logf("Trying to remove non-existing key")
+	removed, err = s.Remove(blks[0].Cid().Bytes())
+	require.NoError(t, err)
+	require.False(t, removed)
+
+	s.Flush()
+
+	// Start iterator
+	flPath := filepath.Join(tempDir, "storethehash.index.free")
+	fmt.Println(flPath)
+	file, err := os.Open(flPath)
+	require.NoError(t, err)
+	iter := freelist.NewFreeListIter(file)
+	// Check freelist for the only removal. Should be the first position
+	blk, err := iter.Next()
+	require.Equal(t, blk.Offset, types.Position(0))
+	require.NoError(t, err)
+	// Check that is the last
+	_, err = iter.Next()
+	require.EqualError(t, err, io.EOF.Error())
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1,9 +1,7 @@
 package store_test
 
 import (
-	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,8 +30,7 @@ func initStore(t *testing.T, dir string) (*store.Store, error) {
 }
 
 func TestUpdate(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "sth")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	s, err := initStore(t, tempDir)
 	require.NoError(t, err)
 	blks := testutil.GenerateBlocksOfSize(2, 100)
@@ -79,8 +76,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "sth")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	s, err := initStore(t, tempDir)
 	require.NoError(t, err)
 	blks := testutil.GenerateBlocksOfSize(2, 100)
@@ -114,7 +110,6 @@ func TestRemove(t *testing.T) {
 
 	// Start iterator
 	flPath := filepath.Join(tempDir, "storethehash.index.free")
-	fmt.Println(flPath)
 	file, err := os.Open(flPath)
 	require.NoError(t, err)
 	iter := freelist.NewFreeListIter(file)


### PR DESCRIPTION
This PR: 
- Implements phase 1 of the `remove` implementation described in #5 to enable the implementation of storage interface in storetheindex https://github.com/filecoin-project/storetheindex/issues/7
- Fixes and error that caused the freelist to not to `Flush()` correctly with the rest of the storage.

Coming next: 
- Compaction
- https://github.com/ipld/go-storethehash/issues/7

//cc @gammazero 