### PR TITLE
fix: staticcheck errors

### DIFF
--- a/store/index/index.go
+++ b/store/index/index.go
@@ -178,7 +178,7 @@ func scanIndex(path string, indexSizeBits uint8) (Buckets, SizeBuckets, error) {
 	buffered := bufio.NewReader(file)
 	iter := NewIndexIter(buffered, types.Position(bytesRead))
 	for {
-		data, pos, err, done := iter.Next()
+		data, pos, done, err := iter.Next()
 		if done {
 			break
 		}
@@ -611,7 +611,7 @@ func NewIndexIter(index io.Reader, pos types.Position) *IndexIter {
 	return &IndexIter{index, pos}
 }
 
-func (iter *IndexIter) Next() ([]byte, types.Position, error, bool) {
+func (iter *IndexIter) Next() ([]byte, types.Position, bool, error) {
 	size, err := ReadSizePrefix(iter.index)
 	switch err {
 	case nil:
@@ -620,13 +620,13 @@ func (iter *IndexIter) Next() ([]byte, types.Position, error, bool) {
 		data := make([]byte, size)
 		_, err := io.ReadFull(iter.index, data)
 		if err != nil {
-			return nil, 0, err, false
+			return nil, 0, false, err
 		}
-		return data, pos, nil, false
+		return data, pos, false, nil
 	case io.EOF:
-		return nil, 0, nil, true
+		return nil, 0, true, nil
 	default:
-		return nil, 0, err, false
+		return nil, 0, false, err
 	}
 }
 

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -71,7 +71,7 @@ func assertCommonPrefixTrimmed(t *testing.T, key1 []byte, key2 []byte, expectedK
 
 	// The record list is append only, hence the first record list only contains the first insert
 	{
-		data, _, err, done := iter.Next()
+		data, _, done, err := iter.Next()
 		require.NoError(t, err)
 		require.False(t, done)
 		recordlist := index.NewRecordList(data)
@@ -86,7 +86,7 @@ func assertCommonPrefixTrimmed(t *testing.T, key1 []byte, key2 []byte, expectedK
 
 	// The second block contains both keys
 	{
-		data, _, err, done := iter.Next()
+		data, _, done, err := iter.Next()
 		require.NoError(t, err)
 		require.False(t, done)
 		recordlist := index.NewRecordList(data)
@@ -128,7 +128,7 @@ func TestIndexPutSingleKey(t *testing.T) {
 	_, bytesRead, err := index.ReadHeader(file)
 	require.NoError(t, err)
 	iter := index.NewIndexIter(file, bytesRead)
-	data, _, err, done := iter.Next()
+	data, _, done, err := iter.Next()
 	require.NoError(t, err)
 	require.False(t, done)
 	recordlist := index.NewRecordList(data)
@@ -244,7 +244,7 @@ func TestIndexPutDistinctKey(t *testing.T) {
 	// The record list is append only, hence the first record list only contains the first insert
 	var data []byte
 	for {
-		next, _, err, done := iter.Next()
+		next, _, done, err := iter.Next()
 		require.NoError(t, err)
 		if done {
 			break
@@ -340,7 +340,7 @@ func TestIndexPutPrevAndNextKeyCommonPrefix(t *testing.T) {
 
 	var data []byte
 	for {
-		next, _, err, done := iter.Next()
+		next, _, done, err := iter.Next()
 		require.NoError(t, err)
 		if done {
 			break

--- a/store/index/recordlist_test.go
+++ b/store/index/recordlist_test.go
@@ -91,12 +91,14 @@ func TestRecordListFindKeyPosition(t *testing.T) {
 
 	// Between to keys with both having a different prefix
 	pos, prevRecord, hasPrev = records.FindKeyPosition([]byte("c"))
+	require.True(t, hasPrev)
 	require.Equal(t, pos, 43)
 	require.Equal(t, prevRecord.Key, []byte("b"))
 
 	// Between two keys with both having a different prefix and the input key having a
 	// different length
 	pos, prevRecord, _ = records.FindKeyPosition([]byte("cabefg"))
+
 	require.Equal(t, pos, 43)
 	require.Equal(t, prevRecord.Key, []byte("b"))
 
@@ -108,18 +110,18 @@ func TestRecordListFindKeyPosition(t *testing.T) {
 
 	// Between two keys with both having a different prefix, no charachter in in common and
 	// different length (shorter than the input key)
-	pos, prevRecord, hasPrev = records.FindKeyPosition([]byte("hello"))
+	pos, prevRecord, _ = records.FindKeyPosition([]byte("hello"))
 	require.Equal(t, pos, 87)
 	require.Equal(t, prevRecord.Key, []byte("dn"))
 
 	// Between two keys with both having a different prefix, no charachter in in common and
 	// different length (longer than the input key)
-	pos, prevRecord, hasPrev = records.FindKeyPosition([]byte("pz"))
+	pos, prevRecord, _ = records.FindKeyPosition([]byte("pz"))
 	require.Equal(t, pos, 103)
 	require.Equal(t, prevRecord.Key, []byte("nky"))
 
 	// Last key
-	pos, prevRecord, hasPrev = records.FindKeyPosition([]byte("z"))
+	pos, prevRecord, _ = records.FindKeyPosition([]byte("z"))
 	require.Equal(t, pos, 121)
 	require.Equal(t, prevRecord.Key, []byte("xrlfg"))
 }

--- a/store/primary/inmemory/inmemory_test.go
+++ b/store/primary/inmemory/inmemory_test.go
@@ -37,10 +37,13 @@ func TestPut(t *testing.T) {
 	storage := inmemory.NewInmemory([][2][]byte{})
 
 	put_aa, err := storage.Put(aa[0], aa[1])
+	require.NoError(t, err)
 	require.Equal(t, put_aa, types.Block{Offset: 0, Size: 1})
 	put_yy, err := storage.Put(yy[0], yy[1])
+	require.NoError(t, err)
 	require.Equal(t, put_yy, types.Block{Offset: 1, Size: 1})
 	put_efg, err := storage.Put(efg[0], efg[1])
+	require.NoError(t, err)
 	require.Equal(t, put_efg, types.Block{Offset: 2, Size: 1})
 
 	key, value, err := storage.Get(types.Block{Offset: 0})

--- a/store/store.go
+++ b/store/store.go
@@ -154,7 +154,7 @@ func (s *Store) Get(key []byte) ([]byte, bool, error) {
 
 	// The index stores only prefixes, hence check if the given key fully matches the
 	// key that is stored in the primary storage before returning the actual value.
-	if bytes.Compare(indexKey, primaryKey) != 0 {
+	if !bytes.Equal(indexKey, primaryKey) {
 		return nil, false, nil
 	}
 	return value, true, nil
@@ -389,8 +389,8 @@ func (s *Store) Has(key []byte) (bool, error) {
 		return false, err
 	}
 	blk, found, err := s.index.Get(indexKey)
-	if !found {
-		return false, nil
+	if !found || err != nil {
+		return false, err
 	}
 
 	// The index stores only prefixes, hence check if the given key fully matches the
@@ -401,7 +401,7 @@ func (s *Store) Has(key []byte) (bool, error) {
 		return false, err
 	}
 
-	return bytes.Compare(indexKey, primaryIndexKey) == 0, nil
+	return bytes.Equal(indexKey, primaryIndexKey), nil
 }
 
 func (s *Store) GetSize(key []byte) (types.Size, bool, error) {
@@ -425,7 +425,7 @@ func (s *Store) GetSize(key []byte) (types.Size, bool, error) {
 		return 0, false, err
 	}
 
-	if bytes.Compare(indexKey, primaryIndexKey) != 0 {
+	if !bytes.Equal(indexKey, primaryIndexKey) {
 		return 0, false, nil
 	}
 	return blk.Size - types.Size(len(key)), true, nil


### PR DESCRIPTION
Also:

1. A bug where we dropped an error.
2. BREAKING: This reorders the return values from iter.Next to be idiomatic. Specifically, it puts the error _last_.