### PR TITLE
Fix race on Store.Close

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -109,8 +109,8 @@ func (s *Store) Close() error {
 
 	if running {
 		close(s.closing)
+		<-s.closed
 	}
-	<-s.closed
 
 	var err error
 	if s.outstandingWork() {

--- a/store/store.go
+++ b/store/store.go
@@ -28,6 +28,7 @@ type Store struct {
 	burstRate types.Work
 	lastFlush time.Time
 
+	closed       chan struct{}
 	closing      chan struct{}
 	flushNow     chan struct{}
 	syncInterval time.Duration
@@ -50,6 +51,7 @@ func OpenStore(path string, primary primary.PrimaryStorage, indexSizeBits uint8,
 		running:      false,
 		syncInterval: syncInterval,
 		burstRate:    burstRate,
+		closed:       make(chan struct{}),
 		closing:      make(chan struct{}),
 		flushNow:     make(chan struct{}, 1),
 	}
@@ -67,6 +69,7 @@ func (s *Store) Start() {
 }
 
 func (s *Store) run() {
+	defer close(s.closed)
 	d := time.NewTicker(s.syncInterval)
 
 	for {
@@ -107,6 +110,7 @@ func (s *Store) Close() error {
 	if running {
 		close(s.closing)
 	}
+	<-s.closed
 
 	var err error
 	if s.outstandingWork() {

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.0.1"
+  "version": "v0.0.2"
 }


### PR DESCRIPTION
If the run goroutine is in the process of performing a flush when the store is closed, this can cause a race.  To fix this, Close waits for the run goroutine to exit before continuing to close and commit/flush.