### PR TITLE
Fix corrupted index files

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.1.0"
+  "version": "v0.1.1"
 }


### PR DESCRIPTION
It is possible for an index file to have incomplete data if a process is terminated unexpectedly.  This will cause an error reading the bad index file and it will not be fixed until file is repaired or deleted.  This change removes the damaged portion of the index file and allows the remaining data in the file to continue being used.