### PR TITLE
Upgrade sets file boundry at same place as write 

### DIFF
--- a/store/index/upgrade.go
+++ b/store/index/upgrade.go
@@ -72,8 +72,8 @@ func chunkOldIndex(file *os.File, name string, fileSizeLimit int64) (uint32, err
 	if err != nil {
 		return 0, err
 	}
-	writer := bufio.NewWriter(outFile)
-	reader := bufio.NewReaderSize(file, 32*1024)
+	writer := bufio.NewWriterSize(outFile, indexBufferSize)
+	reader := bufio.NewReaderSize(file, indexBufferSize)
 
 	sizeBuffer := make([]byte, SizePrefixSize)
 	var written int64
@@ -101,7 +101,7 @@ func chunkOldIndex(file *os.File, name string, fileSizeLimit int64) (uint32, err
 			return 0, fmt.Errorf("count not read complete entry from index")
 		}
 		written += SizePrefixSize + int64(size)
-		if written > fileSizeLimit {
+		if written >= fileSizeLimit {
 			if err = writer.Flush(); err != nil {
 				return 0, err
 			}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.1.2"
+  "version": "v0.1.3"
 }


### PR DESCRIPTION
Both write and upgrade should start a new index file when the bytes written is >= the size limit.  Previously on used > and one used >=.

- Use `indexBufferSize` for all io buffers.
- Do not allocate buckets until after upgrade.