### PR TITLE
Flush write buffer when Flush is called

### DIFF
--- a/store/freelist/freelist.go
+++ b/store/freelist/freelist.go
@@ -3,6 +3,7 @@ package freelist
 import (
 	"bufio"
 	"encoding/binary"
+	"fmt"
 	"os"
 	"sync"
 
@@ -89,6 +90,11 @@ func (cp *FreeList) commit() (types.Work, error) {
 		}
 		work += blockWork
 	}
+	err := cp.writer.Flush()
+	if err != nil {
+		return 0, fmt.Errorf("cannot flush data to freelist file %s: %w", cp.file.Name(), err)
+	}
+
 	return work, nil
 }
 

--- a/store/freelist/freelist.go
+++ b/store/freelist/freelist.go
@@ -21,8 +21,13 @@ type FreeList struct {
 	poolLk            sync.RWMutex
 }
 
-const blockBufferSize = 32 * 4096
-const blockPoolSize = 1024
+const (
+	// blockBufferSize is the size of I/O buffers. If has the same size as the
+	// linux pipe size.
+	blockBufferSize = 16 * 4096
+	// blockPoolSize is the size of the freelist cache.
+	blockPoolSize = 1024
+)
 
 type blockPool struct {
 	blocks []types.Block
@@ -149,7 +154,6 @@ func (cpi *FreeListIter) Next() (*types.Block, error) {
 
 	_, err = cpi.reader.ReadAt(sizeBuf, int64(cpi.pos))
 	if err != nil {
-
 		return nil, err
 	}
 	cpi.pos += types.SizeBytesLen

--- a/store/index/gc.go
+++ b/store/index/gc.go
@@ -123,7 +123,7 @@ func (i *Index) gcIndexFile(ctx context.Context, fileNum uint32, indexPath strin
 	defer file.Close()
 
 	inBuf := bufio.NewReader(file)
-	sizeBuffer := make([]byte, SizePrefixSize)
+	sizeBuffer := make([]byte, sizePrefixSize)
 	scratch := make([]byte, 256)
 	for {
 		if ctx.Err() != nil {

--- a/store/index/index.go
+++ b/store/index/index.go
@@ -389,8 +389,14 @@ func (i *Index) Put(key []byte, location types.Block) error {
 				// The previous key, read from the primary, was bad. This means
 				// that the data in the primary at prevRecord.Bucket is not
 				// good, or that data in the index is bad and prevRecord.Bucket
-				// has a wrong location in the primary.
-				log.Errorw("Read bad previous key from primary, too short")
+				// has a wrong location in the primary.  Log the error with
+				// diagnostic information.
+				cached, indexOffset, recordListSize, fileNum, err := i.readBucketInfo(bucket)
+				if err != nil {
+					log.Errorw("Cannot read bucket", "err", err)
+				} else {
+					log.Errorw("Read bad pevious key data, too short", "cached", cached, "pos", indexOffset, "size", recordListSize, "file", indexFileName(i.basePath, fileNum))
+				}
 				// Either way, the previous key record is not usable, so
 				// overwrite it with a record for the new key.  Use the same
 				// key in the index record as the previous record, since the

--- a/store/index/index.go
+++ b/store/index/index.go
@@ -56,13 +56,26 @@ The format of that append only log is:
 // stale data that GC cannot remove.  Using a 1GiB index file size limit offers
 // a good balance, and this value should not be changed (other than for
 // testing) by more than a factor of 4.
-const maxFileSize = 1024 * 1024 * 1024
 
-// IndexVersion is stored in the header data to indicate how to interpred index data.
-const IndexVersion = 3
+const (
+	// IndexVersion is stored in the header data to indicate how to interpred
+	// index data.
+	IndexVersion = 3
 
-// Number of bytes used for the size prefix of a record list.
-const SizePrefixSize = 4
+	// maxFileSize is the size at which a new index file must be started.
+	maxFileSize = 1024 * 1024 * 1024
+
+	// sizePrefixSize is the number of bytes used for the size prefix of a
+	// record list.
+	sizePrefixSize = 4
+
+	// indexBufferSize is the size of I/O buffers. If has the same size as the
+	// linux pipe size.
+	indexBufferSize = 16 * 4096
+
+	// bucketPoolSize is the bucket cache size.
+	bucketPoolSize = 1024
+)
 
 // Remove the prefix that is used for the bucket.
 //
@@ -113,11 +126,7 @@ type Index struct {
 	gcDone            chan struct{}
 }
 
-const indexBufferSize = 32 * 4096
-
 type bucketPool map[BucketIndex][]byte
-
-const BucketPoolSize = 1024
 
 // Open and index.
 //
@@ -186,8 +195,8 @@ func OpenIndex(path string, primary primary.PrimaryStorage, indexSizeBits uint8,
 		writer:      bufio.NewWriterSize(file, indexBufferSize),
 		Primary:     primary,
 		bucketLk:    sync.RWMutex{},
-		curPool:     make(bucketPool, BucketPoolSize),
-		nextPool:    make(bucketPool, BucketPoolSize),
+		curPool:     make(bucketPool, bucketPoolSize),
+		nextPool:    make(bucketPool, bucketPoolSize),
 		length:      types.Position(fi.Size()),
 		basePath:    path,
 		updateSig:   make(chan struct{}, 1),
@@ -274,7 +283,7 @@ func scanIndexFile(basePath string, fileNum uint32, buckets Buckets, sizeBuckets
 	defer file.Close()
 
 	buffered := bufio.NewReaderSize(file, indexBufferSize)
-	sizeBuffer := make([]byte, SizePrefixSize)
+	sizeBuffer := make([]byte, sizePrefixSize)
 	scratch := make([]byte, 256)
 	var iterPos int64
 	for {
@@ -294,7 +303,7 @@ func scanIndexFile(basePath string, fileNum uint32, buckets Buckets, sizeBuckets
 		}
 		size := binary.LittleEndian.Uint32(sizeBuffer)
 
-		pos := iterPos + SizePrefixSize
+		pos := iterPos + sizePrefixSize
 		iterPos = pos + int64(size)
 		if int(size) > len(scratch) {
 			scratch = make([]byte, size)
@@ -308,7 +317,7 @@ func scanIndexFile(basePath string, fileNum uint32, buckets Buckets, sizeBuckets
 				log.Errorw("Unexpected EOF scanning index record", "file", indexPath)
 				file.Close()
 				// Cut off incomplete data
-				os.Truncate(indexPath, pos-SizePrefixSize)
+				os.Truncate(indexPath, pos-sizePrefixSize)
 				break
 			}
 			return err
@@ -367,7 +376,7 @@ func (i *Index) Put(key []byte, location types.Block) error {
 			// from the one that should get inserted.
 			fullPrevKey, err := i.Primary.GetIndexKey(prevRecord.Block)
 			if err != nil {
-				return err
+				return fmt.Errorf("error reading previous key from primary: %w", err)
 			}
 			// The index key has already removed the prefix that is used to determine the
 			// bucket. Do the same for the full previous key.
@@ -382,7 +391,8 @@ func (i *Index) Put(key []byte, location types.Block) error {
 			if keyTrimPos < len(prevKey) {
 				trimmedPrevKey = prevKey[:keyTrimPos+1]
 			} else {
-				// trimmedPrevKey should always be a prefix. since it isn't here, collect some diagnostic logs.
+				// trimmedPrevKey should always be a prefix. since it is not
+				// here, collect some diagnostic logs.
 				cached, indexOffset, recordListSize, fileNum, err := i.readBucketInfo(bucket)
 				if err != nil {
 					log.Errorw("Cannot read bucket", "err", err)
@@ -393,8 +403,8 @@ func (i *Index) Put(key []byte, location types.Block) error {
 			trimmedIndexKey := indexKey[:keyTrimPos+1]
 			var keys []KeyPositionPair
 
-			// Replace the existing previous key (which is too short) with a new one and
-			// also insert the new key.
+			// Replace the existing previous key (which is too short) with a
+			// new one and also insert the new key.
 			if bytes.Compare(trimmedPrevKey, trimmedIndexKey) == -1 {
 				keys = []KeyPositionPair{
 					{trimmedPrevKey, prevRecord.Block},
@@ -411,40 +421,38 @@ func (i *Index) Put(key []byte, location types.Block) error {
 			// already guaranteed to be distinguishable from the new key as it was already
 			// distinguishable from the previous key.
 		} else {
-
 			// The previous key is not fully contained in the key that should get inserted.
 			// Hence we only need to trim the new key to the smallest one possible that is
 			// still distinguishable from the previous (in case there is one) and next key
 			// (in case there is one).
-
 			prevRecordNonCommonBytePos := 0
 			if has {
 				prevRecordNonCommonBytePos = firstNonCommonByte(indexKey, prevRecord.Key)
 			}
-			// The new record won't be the last record
+			// The new record will not be the last record.
 			nextRecordNonCommonBytePos := 0
 			if pos < records.Len() {
-				// In order to determine the minimal key size, we need to get the next key
-				// as well.
+				// In order to determine the minimal key size, we need to get
+				// the next key as well.
 				nextRecord := records.ReadRecord(pos)
 				nextRecordNonCommonBytePos = firstNonCommonByte(indexKey, nextRecord.Key)
 			}
 
-			// Minimum prefix of the key that is different in at least one byte from the
-			// previous as well as the next key.
+			// Minimum prefix of the key that is different in at least one byte
+			// from the previous as well as the next key.
 			minPrefix := max(
 				prevRecordNonCommonBytePos,
 				nextRecordNonCommonBytePos,
 			)
 
-			// We cannot trim beyond the key length
+			// We cannot trim beyond the key length.
 			keyTrimPos := min(minPrefix, len(indexKey)-1)
 
 			trimmedIndexKey := indexKey[:keyTrimPos+1]
 			newData = records.PutKeys([]KeyPositionPair{{trimmedIndexKey, location}}, pos, pos)
 		}
 	}
-	i.outstandingWork += types.Work(len(newData) + BucketPrefixSize + SizePrefixSize)
+	i.outstandingWork += types.Work(len(newData) + BucketPrefixSize + sizePrefixSize)
 	i.nextPool[bucket] = newData
 	return nil
 }
@@ -463,17 +471,17 @@ func (i *Index) Update(key []byte, location types.Block) error {
 		return err
 	}
 
-	// The key doesn't need the prefix that was used to find the right bucket. For simplicity
-	// only full bytes are trimmed off.
+	// The key does not need the prefix that was used to find its bucket. For
+	// simplicity only full bytes are trimmed off.
 	indexKey := StripBucketPrefix(key, i.sizeBits)
 
 	var newData []byte
-	// If no records stored in that bucket yet it means there is no key
-	// to be updated.
+	// If no records are stored in that bucket yet, it means there is no key to
+	// be updated.
 	if records == nil {
 		return fmt.Errorf("no records found in index, unable to update key")
 	} else {
-		// Read the record list to find the key and position
+		// Read the record list to find the key and position.
 		r := records.GetRecord(indexKey)
 		if r == nil {
 			return fmt.Errorf("key to update not found in index")
@@ -483,7 +491,7 @@ func (i *Index) Update(key []byte, location types.Block) error {
 		newData = records.PutKeys([]KeyPositionPair{{r.Key, location}}, r.Pos, r.NextPos())
 	}
 
-	i.outstandingWork += types.Work(len(newData) + BucketPrefixSize + SizePrefixSize)
+	i.outstandingWork += types.Work(len(newData) + BucketPrefixSize + sizePrefixSize)
 	i.nextPool[bucket] = newData
 	return nil
 }
@@ -502,22 +510,22 @@ func (i *Index) Remove(key []byte) (bool, error) {
 		return false, err
 	}
 
-	// The key doesn't need the prefix that was used to find the right bucket. For simplicity
-	// only full bytes are trimmed off.
+	// The key does not need the prefix that was used to find its bucket. For
+	// simplicity only full bytes are trimmed off.
 	indexKey := StripBucketPrefix(key, i.sizeBits)
 
 	var newData []byte
-	// If no records stored in that bucket yet it means there is no key
-	// to be removed.
+	// If no records are stored in that bucket yet, it means there is no key to
+	// be removed.
 	if records == nil {
 		// No records in index. Nothing to remove.
 		return false, nil
 	}
 
-	// Read the record list to find the key and position
+	// Read the record list to find the key and its position.
 	r := records.GetRecord(indexKey)
 	if r == nil {
-		// The record doesn't exist. Nothing to remove
+		// The record does not exist. Nothing to remove.
 		return false, nil
 	}
 
@@ -528,7 +536,7 @@ func (i *Index) Remove(key []byte) (bool, error) {
 	// and see if any of them can be shortened. This process will be similar
 	// to finding where to put a new key.
 
-	i.outstandingWork += types.Work(len(newData) + BucketPrefixSize + SizePrefixSize)
+	i.outstandingWork += types.Work(len(newData) + BucketPrefixSize + sizePrefixSize)
 	i.nextPool[bucket] = newData
 	return true, nil
 }
@@ -538,8 +546,8 @@ func (i *Index) getBucketIndex(key []byte) (BucketIndex, error) {
 		return 0, types.ErrKeyTooShort
 	}
 
-	// Determine which bucket a key falls into. Use the first few bytes of they key for it and
-	// interpret them as a little-endian integer.
+	// Determine which bucket a key falls into. Use the first few bytes of they
+	// key for it and interpret them as a little-endian integer.
 	prefix := BucketIndex(binary.LittleEndian.Uint32(key))
 	var leadingBits BucketIndex = (1 << i.sizeBits) - 1
 	return prefix & leadingBits, nil
@@ -550,7 +558,7 @@ func (i *Index) getRecordsFromBucket(bucket BucketIndex) (RecordList, error) {
 	// Get the index file offset of the record list the key is in.
 	cached, indexOffset, recordListSize, fileNum, err := i.readBucketInfo(bucket)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading bucket info: %w", err)
 	}
 	var records RecordList
 	if cached != nil {
@@ -558,7 +566,7 @@ func (i *Index) getRecordsFromBucket(bucket BucketIndex) (RecordList, error) {
 	} else {
 		records, err = i.readDiskBucket(indexOffset, recordListSize, fileNum)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error reading index records from disk: %w", err)
 		}
 	}
 	return records, nil
@@ -577,10 +585,10 @@ func (i *Index) flushBucket(bucket BucketIndex, newData []byte) (types.Block, ty
 		}
 		file, err := openFileAppend(indexPath)
 		if err != nil {
-			return types.Block{}, 0, err
+			return types.Block{}, 0, fmt.Errorf("cannot open new index file %s: %w", indexPath, err)
 		}
 		if err = i.writer.Flush(); err != nil {
-			return types.Block{}, 0, err
+			return types.Block{}, 0, fmt.Errorf("cannot write to index file %s: %w", i.file.Name(), err)
 		}
 		i.file.Close()
 		i.writer.Reset(file)
@@ -589,9 +597,10 @@ func (i *Index) flushBucket(bucket BucketIndex, newData []byte) (types.Block, ty
 		i.length = 0
 	}
 
-	// Write new data to disk. The record list is prefixed with bucket they are in. This is
-	// needed in order to reconstruct the in-memory buckets from the index itself.
-	newDataSize := make([]byte, SizePrefixSize)
+	// Write new data to disk. The record list is prefixed with the bucket they
+	// are in. This is needed in order to reconstruct the in-memory buckets
+	// from the index itself.
+	newDataSize := make([]byte, sizePrefixSize)
 	binary.LittleEndian.PutUint32(newDataSize, uint32(len(newData))+uint32(BucketPrefixSize))
 	_, err := i.writer.Write(newDataSize)
 	if err != nil {
@@ -608,13 +617,13 @@ func (i *Index) flushBucket(bucket BucketIndex, newData []byte) (types.Block, ty
 		return types.Block{}, 0, err
 	}
 	length := i.length
-	toWrite := types.Position(len(newData) + BucketPrefixSize + SizePrefixSize)
+	toWrite := types.Position(len(newData) + BucketPrefixSize + sizePrefixSize)
 	i.length += toWrite
 	// Fsyncs are expensive, so do not do them here; do in explicit Sync().
 
-	// Keep the reference to the stored data in the bucket
+	// Keep the reference to the stored data in the bucket.
 	return types.Block{
-		Offset: localPosToBucketPos(int64(length+SizePrefixSize), i.fileNum),
+		Offset: localPosToBucketPos(int64(length+sizePrefixSize), i.fileNum),
 		Size:   types.Size(len(newData) + BucketPrefixSize),
 	}, types.Work(toWrite), nil
 }
@@ -644,15 +653,19 @@ func (i *Index) commit() (types.Work, error) {
 		blks = append(blks, bucketBlock{bucket, blk})
 		work += newWork
 	}
+	err := i.writer.Flush()
+	if err != nil {
+		return 0, fmt.Errorf("cannot flush data to index file %s: %w", i.file.Name(), err)
+	}
 	i.bucketLk.Lock()
 	defer i.bucketLk.Unlock()
 	for _, blk := range blks {
 		bucket := blk.bucket
-		if err := i.buckets.Put(bucket, blk.blk.Offset); err != nil {
-			return 0, err
+		if err = i.buckets.Put(bucket, blk.blk.Offset); err != nil {
+			return 0, fmt.Errorf("error commiting bucket: %w", err)
 		}
-		if err := i.sizeBuckets.Put(bucket, blk.blk.Size); err != nil {
-			return 0, err
+		if err = i.sizeBuckets.Put(bucket, blk.blk.Size); err != nil {
+			return 0, fmt.Errorf("error commiting size bucket: %w", err)
 		}
 	}
 	// Send signal to update index checkpoint.
@@ -675,11 +688,11 @@ func (i *Index) readBucketInfo(bucket BucketIndex) ([]byte, types.Position, type
 	}
 	bucketPos, err := i.buckets.Get(bucket)
 	if err != nil {
-		return nil, 0, 0, 0, err
+		return nil, 0, 0, 0, fmt.Errorf("error reading bucket: %w", err)
 	}
 	recordListSize, err := i.sizeBuckets.Get(bucket)
 	if err != nil {
-		return nil, 0, 0, 0, err
+		return nil, 0, 0, 0, fmt.Errorf("error reading size bucket: %w", err)
 	}
 	localPos, fileNum := localizeBucketPos(bucketPos)
 	return nil, localPos, recordListSize, fileNum, nil
@@ -687,7 +700,7 @@ func (i *Index) readBucketInfo(bucket BucketIndex) ([]byte, types.Position, type
 
 func (i *Index) readDiskBucket(indexOffset types.Position, recordListSize types.Size, fileNum uint32) (RecordList, error) {
 	// indexOffset should never be 0 is there is a bucket, because it is always
-	// SizePrefixSize into the stored data.
+	// at lease sizePrefixSize into the stored data.
 	if indexOffset == 0 {
 		return nil, nil
 	}
@@ -698,8 +711,8 @@ func (i *Index) readDiskBucket(indexOffset types.Position, recordListSize types.
 	}
 	defer file.Close()
 
-	// Read the record list from disk and get the file offset of that key in the primary
-	// storage.
+	// Read the record list from disk and get the file offset of that key in
+	// the primary storage.
 	data := make([]byte, recordListSize)
 	if _, err = file.ReadAt(data, int64(indexOffset)); err != nil {
 		return nil, err
@@ -709,20 +722,20 @@ func (i *Index) readDiskBucket(indexOffset types.Position, recordListSize types.
 
 // Get the file offset in the primary storage of a key.
 func (i *Index) Get(key []byte) (types.Block, bool, error) {
-	// Get record list and bucket index
+	// Get record list and bucket index.
 	bucket, err := i.getBucketIndex(key)
 	if err != nil {
 		return types.Block{}, false, err
 	}
 
-	// Here we just need an RLock, there won't be changes over buckets.
-	// This is why we don't use getRecordsFromBucket to wrap only this
-	// line of code in the lock
+	// Here we just need an RLock since there will not be changes over buckets.
+	// So, do not use getRecordsFromBucket and instead only wrap this line of
+	// code in the RLock.
 	i.bucketLk.RLock()
 	cached, indexOffset, recordListSize, fileNum, err := i.readBucketInfo(bucket)
 	i.bucketLk.RUnlock()
 	if err != nil {
-		return types.Block{}, false, err
+		return types.Block{}, false, fmt.Errorf("error reading bucket: %w", err)
 	}
 	var records RecordList
 	if cached != nil {
@@ -730,15 +743,15 @@ func (i *Index) Get(key []byte) (types.Block, bool, error) {
 	} else {
 		records, err = i.readDiskBucket(indexOffset, recordListSize, fileNum)
 		if err != nil {
-			return types.Block{}, false, err
+			return types.Block{}, false, fmt.Errorf("error reading index records from disk: %w", err)
 		}
 	}
 	if records == nil {
 		return types.Block{}, false, nil
 	}
 
-	// The key doesn't need the prefix that was used to find the right bucket. For simplicity
-	// only full bytes are trimmed off.
+	// The key does not need the prefix that was used to find its bucket. For
+	// simplicity only full bytes are trimmed off.
 	indexKey := StripBucketPrefix(key, i.sizeBits)
 
 	fileOffset, found := records.Get(indexKey)
@@ -757,7 +770,7 @@ func (i *Index) Sync() error {
 		return err
 	}
 	i.bucketLk.Lock()
-	i.curPool = make(bucketPool, BucketPoolSize)
+	i.curPool = make(bucketPool, bucketPoolSize)
 	i.bucketLk.Unlock()
 	return nil
 }
@@ -765,6 +778,12 @@ func (i *Index) Sync() error {
 func (i *Index) Close() error {
 	close(i.updateSig)
 	<-i.gcDone
+	i.updateSig = nil
+	_, err := i.Flush()
+	if err != nil {
+		i.file.Close()
+		return err
+	}
 	return i.file.Close()
 }
 
@@ -776,8 +795,8 @@ func (i *Index) OutstandingWork() types.Work {
 
 // An iterator over index entries.
 //
-// On each iteration it returns the position of the record within the index together with the raw
-// record list data.
+// On each iteration it returns the position of the record within the index
+// together with the raw record list data.
 type IndexIter struct {
 	// The index data we are iterating over
 	index io.ReadCloser
@@ -812,8 +831,8 @@ func (iter *IndexIter) Next() ([]byte, types.Position, bool, error) {
 	size, err := readSizePrefix(iter.index)
 	switch err {
 	case nil:
-		pos := iter.pos + types.Position(SizePrefixSize)
-		iter.pos += types.Position(SizePrefixSize) + types.Position(size)
+		pos := iter.pos + types.Position(sizePrefixSize)
+		iter.pos += types.Position(sizePrefixSize) + types.Position(size)
 		data := make([]byte, size)
 		_, err := io.ReadFull(iter.index, data)
 		if err != nil {
@@ -841,7 +860,7 @@ func (iter *IndexIter) Close() error {
 
 // Only reads the size prefix of the data and returns it.
 func readSizePrefix(reader io.Reader) (uint32, error) {
-	sizeBuffer := make([]byte, SizePrefixSize)
+	sizeBuffer := make([]byte, sizePrefixSize)
 	_, err := io.ReadFull(reader, sizeBuffer)
 	if err != nil {
 		return 0, err
@@ -918,14 +937,14 @@ func bucketPosToFileNum(pos types.Position) (bool, uint32) {
 		return false, 0
 	}
 	// The start of the entry, not the position of the record, determines which
-	// is file is used.  The record begins SizePrefixSize before pos.  This
+	// is file is used.  The record begins sizePrefixSize before pos.  This
 	// matters only if pos is slightly after a maxFileSize boundry, but
 	// the adjusted position is not.
-	return true, uint32((pos - SizePrefixSize) / maxFileSize)
+	return true, uint32((pos - sizePrefixSize) / maxFileSize)
 }
 
 func localPosToBucketPos(pos int64, fileNum uint32) types.Position {
-	// Valid position must be non-zero, at least SizePrefixSize
+	// Valid position must be non-zero, at least sizePrefixSize.
 	if pos == 0 {
 		panic("invalid local offset")
 	}
@@ -936,9 +955,9 @@ func localPosToBucketPos(pos int64, fileNum uint32) types.Position {
 
 // localizeBucketPos decodes a bucketPos into a local pos and file number.
 func localizeBucketPos(pos types.Position) (types.Position, uint32) {
-	// Bucket pos indicated empty bucket, return 0 local pos to indicate empty.
 	ok, fileNum := bucketPosToFileNum(pos)
 	if !ok {
+		// Return 0 local pos to indicate empty bucket.
 		return 0, 0
 	}
 	// Subtract file offset to get pos within its local file.

--- a/store/index/index.go
+++ b/store/index/index.go
@@ -391,11 +391,16 @@ func (i *Index) Put(key []byte, location types.Block) error {
 				// good, or that data in the index is bad and prevRecord.Bucket
 				// has a wrong location in the primary.  Log the error with
 				// diagnostic information.
-				cached, indexOffset, recordListSize, fileNum, err := i.readBucketInfo(bucket)
+				cached, indexOffset, _, fileNum, err := i.readBucketInfo(bucket)
 				if err != nil {
 					log.Errorw("Cannot read bucket", "err", err)
 				} else {
-					log.Errorw("Read bad pevious key data, too short", "cached", cached, "pos", indexOffset, "size", recordListSize, "file", indexFileName(i.basePath, fileNum))
+					msg := "Read bad pevious key data, too short"
+					if cached == nil {
+						log.Errorw(msg, "offset", indexOffset, "size", indexFileName(i.basePath, fileNum))
+					} else {
+						log.Error(msg)
+					}
 				}
 				// Either way, the previous key record is not usable, so
 				// overwrite it with a record for the new key.  Use the same
@@ -424,11 +429,16 @@ func (i *Index) Put(key []byte, location types.Block) error {
 			} else {
 				// trimmedPrevKey should always be a prefix. since it is not
 				// here, collect some diagnostic logs.
-				cached, indexOffset, recordListSize, fileNum, err := i.readBucketInfo(bucket)
+				cached, indexOffset, _, fileNum, err := i.readBucketInfo(bucket)
 				if err != nil {
 					log.Errorw("Cannot read bucket", "err", err)
 				} else {
-					log.Errorw("Read bad pevious key data", "cached", cached, "pos", indexOffset, "size", recordListSize, "file", indexFileName(i.basePath, fileNum))
+					msg := "Read bad pevious key data"
+					if cached == nil {
+						log.Errorw(msg, "offset", indexOffset, "size", indexFileName(i.basePath, fileNum))
+					} else {
+						log.Error(msg)
+					}
 				}
 			}
 			trimmedIndexKey := indexKey[:keyTrimPos+1]

--- a/store/index/index.go
+++ b/store/index/index.go
@@ -409,8 +409,8 @@ func (i *Index) Put(key []byte, location types.Block) error {
 				// differentiate old from new.
 				//
 				// This results in the data for the previous keys being lost,
-				// but they may not have been present in the first place which
-				// was the cause of this problem.
+				// but it may not have been present in the first place, in which
+				// case that was the cause of this problem.
 				newData = records.PutKeys([]KeyPositionPair{{prevRecord.Key, location}}, prevRecord.Pos, pos)
 				i.outstandingWork += types.Work(len(newData) + BucketPrefixSize + sizePrefixSize)
 				i.nextPool[bucket] = newData

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -492,6 +492,8 @@ func TestIndexGetBad(t *testing.T) {
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
 	i, err := OpenIndex(indexPath, primaryStorage, bucketBits, 0)
+	defer i.Close()
+
 	require.NoError(t, err)
 	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
 	require.NoError(t, err)

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -475,3 +475,58 @@ func TestIndexHeader(t *testing.T) {
 	t.Cleanup(func() { i2.Close() })
 	assertHeader(t, i2.headerPath, bucketBits)
 }
+
+func TestIndexGetBad(t *testing.T) {
+	key1 := []byte{1, 2, 3, 4, 5, 6, 9, 9, 9, 9}
+	key2 := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	key3 := []byte{1, 2, 3, 4, 5, 6, 9, 8, 8, 8}
+	key4 := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+
+	const bucketBits uint8 = 24
+	primaryStorage := inmemory.NewInmemory([][2][]byte{
+		{key1, {0x10}},
+		{[]byte("X"), {0x20}},
+		{key3, {0x30}},
+	})
+
+	tempDir := t.TempDir()
+	indexPath := filepath.Join(tempDir, "storethehash.index")
+	i, err := OpenIndex(indexPath, primaryStorage, bucketBits, 0)
+	require.NoError(t, err)
+	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
+	require.NoError(t, err)
+	err = i.Put(key2, types.Block{Offset: 1, Size: 1})
+	require.NoError(t, err)
+	err = i.Put(key3, types.Block{Offset: 2, Size: 1})
+	require.NoError(t, err)
+
+	firstKeyBlock, found, err := i.Get(key1)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, firstKeyBlock, types.Block{Offset: 0, Size: 1})
+
+	secondKeyBlock, found, err := i.Get(key2)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, secondKeyBlock, types.Block{Offset: 1, Size: 1})
+
+	thirdKeyBlock, found, err := i.Get(key3)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, thirdKeyBlock, types.Block{Offset: 2, Size: 1})
+
+	// This should result in the record for key2 being replaced.
+	err = i.Put(key4, types.Block{Offset: 1, Size: 1})
+	require.NoError(t, err)
+
+	fourthKeyBlock, found, err := i.Get(key4)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, fourthKeyBlock, secondKeyBlock)
+
+	// Index for key2 should be same as index for key4
+	secondKeyBlock, found, err = i.Get(key2)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, secondKeyBlock, fourthKeyBlock)
+}

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -492,7 +492,6 @@ func TestIndexGetBad(t *testing.T) {
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
 	i, err := OpenIndex(indexPath, primaryStorage, bucketBits, 0)
-	defer i.Close()
 
 	require.NoError(t, err)
 	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
@@ -531,4 +530,7 @@ func TestIndexGetBad(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Equal(t, secondKeyBlock, fourthKeyBlock)
+
+	err = i.Close()
+	require.NoError(t, err)
 }

--- a/store/index/recordlist.go
+++ b/store/index/recordlist.go
@@ -24,7 +24,8 @@ const KeySizeBytes int = 1
 // which is a file offset.
 type KeyPositionPair struct {
 	Key []byte
-	// The file offset where the full key and its value is actually stored.
+	// The file offset, into the primary file, where the full key and its value
+	// is actually stored.
 	Block types.Block
 }
 

--- a/store/index/upgrade.go
+++ b/store/index/upgrade.go
@@ -48,7 +48,7 @@ func upgradeIndex(name, headerPath string) error {
 }
 
 func readOldHeader(file *os.File) (byte, byte, types.Position, error) {
-	headerSizeBuffer := make([]byte, SizePrefixSize)
+	headerSizeBuffer := make([]byte, sizePrefixSize)
 	_, err := io.ReadFull(file, headerSizeBuffer)
 	if err != nil {
 		return 0, 0, 0, err
@@ -62,7 +62,7 @@ func readOldHeader(file *os.File) (byte, byte, types.Position, error) {
 	version := headerBytes[0]
 	bucketBits := headerBytes[1]
 
-	return version, bucketBits, types.Position(SizePrefixSize + headerSize), nil
+	return version, bucketBits, types.Position(sizePrefixSize + headerSize), nil
 }
 
 func chunkOldIndex(file *os.File, name string, fileSizeLimit int64) (uint32, error) {
@@ -75,7 +75,7 @@ func chunkOldIndex(file *os.File, name string, fileSizeLimit int64) (uint32, err
 	writer := bufio.NewWriterSize(outFile, indexBufferSize)
 	reader := bufio.NewReaderSize(file, indexBufferSize)
 
-	sizeBuffer := make([]byte, SizePrefixSize)
+	sizeBuffer := make([]byte, sizePrefixSize)
 	var written int64
 	for {
 		_, err = io.ReadFull(reader, sizeBuffer)
@@ -100,7 +100,7 @@ func chunkOldIndex(file *os.File, name string, fileSizeLimit int64) (uint32, err
 			outFile.Close()
 			return 0, fmt.Errorf("count not read complete entry from index")
 		}
-		written += SizePrefixSize + int64(size)
+		written += sizePrefixSize + int64(size)
 		if written >= fileSizeLimit {
 			if err = writer.Flush(); err != nil {
 				return 0, err

--- a/store/index/upgrade_test.go
+++ b/store/index/upgrade_test.go
@@ -102,7 +102,7 @@ func TestChunkOldIndex(t *testing.T) {
 
 func testScanIndexFile(file *os.File, fileNum uint32, buckets Buckets, sizeBuckets SizeBuckets, prevSize int64) error {
 	buffered := bufio.NewReader(file)
-	sizeBuffer := make([]byte, SizePrefixSize)
+	sizeBuffer := make([]byte, sizePrefixSize)
 	scratch := make([]byte, 256)
 	var iterPos int64
 	for {
@@ -115,7 +115,7 @@ func testScanIndexFile(file *os.File, fileNum uint32, buckets Buckets, sizeBucke
 		}
 		size := binary.LittleEndian.Uint32(sizeBuffer)
 
-		pos := iterPos + SizePrefixSize
+		pos := iterPos + sizePrefixSize
 		iterPos = pos + int64(size)
 		if int(size) > len(scratch) {
 			scratch = make([]byte, size)

--- a/store/primary/cid/cid.go
+++ b/store/primary/cid/cid.go
@@ -3,6 +3,7 @@ package cidprimary
 import (
 	"bufio"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -174,6 +175,11 @@ func (cp *CIDPrimary) commit() (types.Work, error) {
 		}
 		work += blockWork
 	}
+	err := cp.writer.Flush()
+	if err != nil {
+		return 0, fmt.Errorf("cannot flush data to primary file %s: %w", cp.file.Name(), err)
+	}
+
 	return work, nil
 }
 
@@ -195,6 +201,11 @@ func (cp *CIDPrimary) Sync() error {
 }
 
 func (cp *CIDPrimary) Close() error {
+	_, err := cp.Flush()
+	if err != nil {
+		cp.file.Close()
+		return err
+	}
 	return cp.file.Close()
 }
 

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.1.4"
+  "version": "v0.1.5"
 }


### PR DESCRIPTION
When Flush was called on the index or the primary, the write buffers were not flushed, so the index or the primary may be written to disk and the other not.  With a hard shutdown this could leave the database in an inconsistent state that can cause errors.  Now the write buffers are flushed when calling Flush.  This helps the situation significantly, but is not a complete solution.  For that, writes to the index and primary would need to be done as a transaction.

Other changes:
- Removed unnecessary exports
- Comments
- Modified buffer size