### PR TITLE
Handle `ReaderAt` error when reading primary

### DIFF
--- a/store/primary/cid/cid.go
+++ b/store/primary/cid/cid.go
@@ -92,7 +92,9 @@ func (cp *CIDPrimary) Get(blk types.Block) (key []byte, value []byte, err error)
 		return
 	}
 	read := make([]byte, CIDSizePrefix+int(blk.Size))
-	cp.file.ReadAt(read, int64(blk.Offset))
+	if _, err = cp.file.ReadAt(read, int64(blk.Offset)); err != nil {
+		return
+	}
 	c, value, err := readNode(read[4:])
 	return c.Bytes(), value, err
 }

--- a/store/primary/multihash/multihash.go
+++ b/store/primary/multihash/multihash.go
@@ -96,7 +96,9 @@ func (cp *MultihashPrimary) Get(blk types.Block) (key []byte, value []byte, err 
 		return
 	}
 	read := make([]byte, int(blk.Size+4))
-	cp.file.ReadAt(read, int64(blk.Offset))
+	if _, err = cp.file.ReadAt(read, int64(blk.Offset)); err != nil {
+		return
+	}
 	h, value, err := readNode(read[4:])
 	return h, value, err
 }


### PR DESCRIPTION
Minor fix to handle `ReaderAt` errors.