### PR TITLE
Index file size is configurable

### DIFF
--- a/store/index/gc_test.go
+++ b/store/index/gc_test.go
@@ -23,6 +23,7 @@ func TestGC(t *testing.T) {
 	dataPath := filepath.Join(tempDir, "storethehash.data")
 	primary, err := mhprimary.OpenMultihashPrimary(dataPath)
 	require.NoError(t, err)
+	defer primary.Close()
 
 	idx, err := OpenIndex(indexPath, primary, 24, 1024, 0)
 	require.NoError(t, err)

--- a/store/index/gc_test.go
+++ b/store/index/gc_test.go
@@ -61,6 +61,11 @@ func TestGC(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, count, 0)
 
+	// Check that first file is .2 and last file is .24
+	header, err := readHeader(idx.headerPath)
+	require.NoError(t, err)
+	require.Equal(t, header.FirstFile, 2)
+	require.Equal(t, idx.fileNum, 24)
 }
 
 func copyFile(src, dst string) error {

--- a/store/index/gc_test.go
+++ b/store/index/gc_test.go
@@ -1,0 +1,81 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mhprimary "github.com/ipld/go-storethehash/store/primary/multihash"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGC(t *testing.T) {
+	tempDir := t.TempDir()
+	indexPath := filepath.Join(tempDir, filepath.Base(testIndexPath))
+
+	// Copy test file.
+	err := copyFile(testIndexPath, indexPath)
+	require.NoError(t, err)
+
+	dataPath := filepath.Join(tempDir, "storethehash.data")
+	primary, err := mhprimary.OpenMultihashPrimary(dataPath)
+	require.NoError(t, err)
+
+	idx, err := OpenIndex(indexPath, primary, 24, 1024, 0)
+	require.NoError(t, err)
+	defer idx.Close()
+
+	// All index files in use, so gc should not remove any files.
+	count, err := idx.gc(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, count, 0)
+
+	require.NoError(t, idx.Close())
+
+	// Copy the first two files as the last two files so that the indexes in
+	// them are associated with the last files.
+	err = copyFile(indexPath+".0", fmt.Sprintf("%s.%d", indexPath, idx.fileNum+1))
+	require.NoError(t, err)
+	err = copyFile(indexPath+".1", fmt.Sprintf("%s.%d", indexPath, idx.fileNum+2))
+	require.NoError(t, err)
+
+	// Open the index with the duplicated files.
+	idx, err = OpenIndex(indexPath, primary, 24, 1024, 0)
+	require.NoError(t, err)
+	defer idx.Close()
+
+	require.False(t, idx.gcCheckpoint)
+
+	// GC should now remove the first 2 files only.
+	count, err = idx.gc(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, count, 2)
+
+	require.True(t, idx.gcCheckpoint)
+
+	// Another GC should not remove files.
+	count, err = idx.gc(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, count, 0)
+
+}
+
+func copyFile(src, dst string) error {
+	fin, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer fin.Close()
+
+	fout, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer fout.Close()
+
+	_, err = io.Copy(fout, fin)
+	return err
+}

--- a/store/index/gc_test.go
+++ b/store/index/gc_test.go
@@ -64,8 +64,8 @@ func TestGC(t *testing.T) {
 	// Check that first file is .2 and last file is .24
 	header, err := readHeader(idx.headerPath)
 	require.NoError(t, err)
-	require.Equal(t, header.FirstFile, 2)
-	require.Equal(t, idx.fileNum, 24)
+	require.Equal(t, header.FirstFile, uint32(2))
+	require.Equal(t, idx.fileNum, uint32(24))
 }
 
 func copyFile(src, dst string) error {

--- a/store/index/upgrade.go
+++ b/store/index/upgrade.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ipld/go-storethehash/store/types"
 )
 
-func upgradeIndex(name, headerPath string) error {
+func upgradeIndex(name, headerPath string, maxFileSize uint32) error {
 	inFile, err := os.Open(name)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -28,13 +28,13 @@ func upgradeIndex(name, headerPath string) error {
 		return fmt.Errorf("cannot convert unknown header version: %d", version)
 	}
 
-	fileNum, err := chunkOldIndex(inFile, name, maxFileSize)
+	fileNum, err := chunkOldIndex(inFile, name, int64(maxFileSize))
 	if err != nil {
 		return err
 	}
 	inFile.Close()
 
-	if err = writeHeader(headerPath, newHeader(bucketBits)); err != nil {
+	if err = writeHeader(headerPath, newHeader(bucketBits, maxFileSize)); err != nil {
 		return err
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -39,8 +39,13 @@ type Store struct {
 	immutable    bool
 }
 
-func OpenStore(path string, primary primary.PrimaryStorage, indexSizeBits uint8, syncInterval time.Duration, burstRate types.Work, gcInterval time.Duration, immutable bool) (*Store, error) {
-	index, err := index.OpenIndex(path, primary, indexSizeBits, gcInterval)
+// OpenStore opens the index and freelist and returns a Store with the given
+// primary.
+//
+// Specifying 0 for indexSizeBits and indexFileSize results in using their
+// default values. A gcInterval of 0 disables garbage collection.
+func OpenStore(path string, primary primary.PrimaryStorage, indexSizeBits uint8, indexFileSize uint32, syncInterval time.Duration, burstRate types.Work, gcInterval time.Duration, immutable bool) (*Store, error) {
+	index, err := index.OpenIndex(path, primary, indexSizeBits, indexFileSize, gcInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 const defaultIndexSizeBits = uint8(24)
+const defaultIndexFileSize = uint32(1024 * 1024 * 1024)
 const defaultBurstRate = 4 * 1024 * 1024
 const defaultSyncInterval = time.Second
 const defaultGCInterval = 0 //30 * time.Minute
@@ -30,7 +31,7 @@ func initStore(t *testing.T, dir string, immutable bool) (*store.Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	store, err := store.OpenStore(indexPath, primary, defaultIndexSizeBits, defaultSyncInterval, defaultBurstRate, defaultGCInterval, immutable)
+	store, err := store.OpenStore(indexPath, primary, defaultIndexSizeBits, defaultIndexFileSize, defaultSyncInterval, defaultBurstRate, defaultGCInterval, immutable)
 	if err != nil {
 		_ = primary.Close()
 		return nil, err
@@ -237,7 +238,7 @@ func TestRecoverBadKey(t *testing.T) {
 	dataPath := filepath.Join(tmpDir, "storethehash.data")
 	primary, err := cidprimary.OpenCIDPrimary(dataPath)
 	require.NoError(t, err)
-	s, err := store.OpenStore(indexPath, primary, defaultIndexSizeBits, defaultSyncInterval, defaultBurstRate, defaultGCInterval, false)
+	s, err := store.OpenStore(indexPath, primary, defaultIndexSizeBits, defaultIndexFileSize, defaultSyncInterval, defaultBurstRate, defaultGCInterval, false)
 	require.NoError(t, err)
 
 	t.Logf("Putting blocks")
@@ -253,7 +254,7 @@ func TestRecoverBadKey(t *testing.T) {
 	// Open store again.
 	primary, err = cidprimary.OpenCIDPrimary(dataPath)
 	require.NoError(t, err)
-	s, err = store.OpenStore(indexPath, primary, defaultIndexSizeBits, defaultSyncInterval, defaultBurstRate, defaultGCInterval, false)
+	s, err = store.OpenStore(indexPath, primary, defaultIndexSizeBits, defaultIndexFileSize, defaultSyncInterval, defaultBurstRate, defaultGCInterval, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, s.Close()) })
 

--- a/storethehash.go
+++ b/storethehash.go
@@ -28,12 +28,14 @@ type HashedBlockstore struct {
 }
 
 const defaultIndexSizeBits = uint8(24)
+const defaultIndexFileSize = uint32(1024 * 1024 * 1024)
 const defaultBurstRate = 4 * 1024 * 1024
 const defaultSyncInterval = time.Second
 const defaultGCInterval = 30 * time.Minute
 
 type configOptions struct {
 	indexSizeBits uint8
+	indexFileSize uint32
 	syncInterval  time.Duration
 	burstRate     types.Work
 	gcInterval    time.Duration
@@ -44,6 +46,12 @@ type Option func(*configOptions)
 func IndexBitSize(indexBitSize uint8) Option {
 	return func(co *configOptions) {
 		co.indexSizeBits = indexBitSize
+	}
+}
+
+func IndexFileSize(indexFileSize uint32) Option {
+	return func(co *configOptions) {
+		co.indexFileSize = indexFileSize
 	}
 }
 
@@ -69,6 +77,7 @@ func GCInterval(gcInterval time.Duration) Option {
 func OpenHashedBlockstore(indexPath string, dataPath string, options ...Option) (*HashedBlockstore, error) {
 	co := configOptions{
 		indexSizeBits: defaultIndexSizeBits,
+		indexFileSize: defaultIndexFileSize,
 		syncInterval:  defaultSyncInterval,
 		burstRate:     defaultBurstRate,
 		gcInterval:    defaultGCInterval,
@@ -80,7 +89,7 @@ func OpenHashedBlockstore(indexPath string, dataPath string, options ...Option) 
 	if err != nil {
 		return nil, err
 	}
-	store, err := store.OpenStore(indexPath, primary, co.indexSizeBits, co.syncInterval, co.burstRate, co.gcInterval, true)
+	store, err := store.OpenStore(indexPath, primary, co.indexSizeBits, co.indexFileSize, co.syncInterval, co.burstRate, co.gcInterval, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Making the index file size configurable is primarily useful for tests that span multiple index files.  It may also be useful for users of storethehash that want different index file sizes for more or less GC granularity.

- GC checkpoint state needed to be part of `Index` instance.
- Add unit tests for garbage collection