### PR TITLE
Use context to cancel startup

### DIFF
--- a/store/index/gc_test.go
+++ b/store/index/gc_test.go
@@ -25,7 +25,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, err)
 	defer primary.Close()
 
-	idx, err := OpenIndex(indexPath, primary, 24, 1024, 0)
+	idx, err := OpenIndex(context.Background(), indexPath, primary, 24, 1024, 0)
 	require.NoError(t, err)
 	defer idx.Close()
 
@@ -44,7 +44,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, err)
 
 	// Open the index with the duplicated files.
-	idx, err = OpenIndex(indexPath, primary, 24, 1024, 0)
+	idx, err = OpenIndex(context.Background(), indexPath, primary, 24, 1024, 0)
 	require.NoError(t, err)
 	defer idx.Close()
 

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -39,7 +40,7 @@ func assertCommonPrefixTrimmed(t *testing.T, key1 []byte, key2 []byte, expectedK
 	primaryStorage := inmemory.NewInmemory([][2][]byte{{key1, {0x20}}, {key2, {0x30}}})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := OpenIndex(indexPath, primaryStorage, bucketBits, fileSize, 0)
+	i, err := OpenIndex(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0)
 	require.NoError(t, err)
 	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
 	require.NoError(t, err)
@@ -97,7 +98,7 @@ func TestIndexPutSingleKey(t *testing.T) {
 	primaryStorage := inmemory.NewInmemory([][2][]byte{})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := OpenIndex(indexPath, primaryStorage, bucketBits, fileSize, 0)
+	i, err := OpenIndex(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0)
 	require.NoError(t, err)
 	err = i.Put([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, types.Block{Offset: 222, Size: 10})
 	require.NoError(t, err)
@@ -136,7 +137,7 @@ func TestIndexRemoveKey(t *testing.T) {
 	primaryStorage := inmemory.NewInmemory([][2][]byte{})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := OpenIndex(indexPath, primaryStorage, bucketBits, fileSize, 0)
+	i, err := OpenIndex(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0)
 	require.NoError(t, err)
 	// Put key 1
 	err = i.Put(k1, b1)
@@ -204,7 +205,7 @@ func TestIndexPutDistinctKey(t *testing.T) {
 	primaryStorage := inmemory.NewInmemory([][2][]byte{})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := OpenIndex(indexPath, primaryStorage, bucketBits, fileSize, 0)
+	i, err := OpenIndex(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0)
 	require.NoError(t, err)
 	err = i.Put([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, types.Block{Offset: 222, Size: 10})
 	require.NoError(t, err)
@@ -244,7 +245,7 @@ func TestCorrectCacheReading(t *testing.T) {
 	primaryStorage := inmemory.NewInmemory([][2][]byte{})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := OpenIndex(indexPath, primaryStorage, bucketBits, fileSize, 0)
+	i, err := OpenIndex(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0)
 	require.NoError(t, err)
 	// put key in, then flush the cache
 	err = i.Put([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, types.Block{Offset: 222, Size: 10})
@@ -297,7 +298,7 @@ func TestIndexPutPrevAndNextKeyCommonPrefix(t *testing.T) {
 	})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := OpenIndex(indexPath, primaryStorage, bucketBits, fileSize, 0)
+	i, err := OpenIndex(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0)
 	require.NoError(t, err)
 	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
 	require.NoError(t, err)
@@ -343,7 +344,7 @@ func TestIndexGetEmptyIndex(t *testing.T) {
 	primaryStorage := inmemory.NewInmemory([][2][]byte{})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	index, err := OpenIndex(indexPath, primaryStorage, bucketBits, fileSize, 0)
+	index, err := OpenIndex(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0)
 	require.NoError(t, err)
 	_, found, err := index.Get(key)
 	require.NoError(t, err)
@@ -364,7 +365,7 @@ func TestIndexGet(t *testing.T) {
 	})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := OpenIndex(indexPath, primaryStorage, bucketBits, fileSize, 0)
+	i, err := OpenIndex(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0)
 	require.NoError(t, err)
 	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
 	require.NoError(t, err)
@@ -431,7 +432,7 @@ func TestIndexGet(t *testing.T) {
 
 	err = i.Close()
 	require.NoError(t, err)
-	i, err = OpenIndex(indexPath, primaryStorage, bucketBits, fileSize, 0)
+	i, err = OpenIndex(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0)
 	require.NoError(t, err)
 
 	// same should hold true when index is closed and reopened
@@ -460,13 +461,13 @@ func TestIndexHeader(t *testing.T) {
 	indexPath := filepath.Join(tempDir, "storethehash.index")
 
 	primaryStorage := inmemory.NewInmemory([][2][]byte{})
-	i1, err := OpenIndex(indexPath, primaryStorage, bucketBits, fileSize, 0)
+	i1, err := OpenIndex(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0)
 	require.NoError(t, err)
 	t.Cleanup(func() { i1.Close() })
 	assertHeader(t, i1.headerPath, bucketBits)
 
 	// Check that the header doesn't change if the index is opened again.
-	i2, err := OpenIndex(indexPath, inmemory.NewInmemory([][2][]byte{}), bucketBits, fileSize, 0)
+	i2, err := OpenIndex(context.Background(), indexPath, inmemory.NewInmemory([][2][]byte{}), bucketBits, fileSize, 0)
 	require.NoError(t, err)
 	t.Cleanup(func() { i2.Close() })
 	assertHeader(t, i2.headerPath, bucketBits)
@@ -486,7 +487,7 @@ func TestIndexGetBad(t *testing.T) {
 
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := OpenIndex(indexPath, primaryStorage, bucketBits, 0, 0)
+	i, err := OpenIndex(context.Background(), indexPath, primaryStorage, bucketBits, 0, 0)
 
 	require.NoError(t, err)
 	err = i.Put(key1, types.Block{Offset: 0, Size: 1})

--- a/store/index/upgrade_test.go
+++ b/store/index/upgrade_test.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"bufio"
+	"context"
 	"encoding/binary"
 	"errors"
 	"io"
@@ -58,7 +59,7 @@ func TestChunkOldIndex(t *testing.T) {
 
 	// Do the upgrade to split the index into multiple files.
 	t.Log("Chunking old index into new index files")
-	lastChunkNum, err := chunkOldIndex(oldFile, newIndexPath, testFileSizeLimit)
+	lastChunkNum, err := chunkOldIndex(context.Background(), oldFile, newIndexPath, testFileSizeLimit)
 	require.NoError(t, err)
 	t.Logf("Split old index into %d files", lastChunkNum)
 

--- a/store/store.go
+++ b/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"sync"
@@ -44,8 +45,8 @@ type Store struct {
 //
 // Specifying 0 for indexSizeBits and indexFileSize results in using their
 // default values. A gcInterval of 0 disables garbage collection.
-func OpenStore(path string, primary primary.PrimaryStorage, indexSizeBits uint8, indexFileSize uint32, syncInterval time.Duration, burstRate types.Work, gcInterval time.Duration, immutable bool) (*Store, error) {
-	index, err := index.OpenIndex(path, primary, indexSizeBits, indexFileSize, gcInterval)
+func OpenStore(ctx context.Context, path string, primary primary.PrimaryStorage, indexSizeBits uint8, indexFileSize uint32, syncInterval time.Duration, burstRate types.Work, gcInterval time.Duration, immutable bool) (*Store, error) {
+	index, err := index.OpenIndex(ctx, path, primary, indexSizeBits, indexFileSize, gcInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"context"
 	"crypto/rand"
 	"io"
 	"os"
@@ -31,7 +32,7 @@ func initStore(t *testing.T, dir string, immutable bool) (*store.Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	store, err := store.OpenStore(indexPath, primary, defaultIndexSizeBits, defaultIndexFileSize, defaultSyncInterval, defaultBurstRate, defaultGCInterval, immutable)
+	store, err := store.OpenStore(context.Background(), indexPath, primary, defaultIndexSizeBits, defaultIndexFileSize, defaultSyncInterval, defaultBurstRate, defaultGCInterval, immutable)
 	if err != nil {
 		_ = primary.Close()
 		return nil, err
@@ -238,7 +239,7 @@ func TestRecoverBadKey(t *testing.T) {
 	dataPath := filepath.Join(tmpDir, "storethehash.data")
 	primary, err := cidprimary.OpenCIDPrimary(dataPath)
 	require.NoError(t, err)
-	s, err := store.OpenStore(indexPath, primary, defaultIndexSizeBits, defaultIndexFileSize, defaultSyncInterval, defaultBurstRate, defaultGCInterval, false)
+	s, err := store.OpenStore(context.Background(), indexPath, primary, defaultIndexSizeBits, defaultIndexFileSize, defaultSyncInterval, defaultBurstRate, defaultGCInterval, false)
 	require.NoError(t, err)
 
 	t.Logf("Putting blocks")
@@ -254,7 +255,7 @@ func TestRecoverBadKey(t *testing.T) {
 	// Open store again.
 	primary, err = cidprimary.OpenCIDPrimary(dataPath)
 	require.NoError(t, err)
-	s, err = store.OpenStore(indexPath, primary, defaultIndexSizeBits, defaultIndexFileSize, defaultSyncInterval, defaultBurstRate, defaultGCInterval, false)
+	s, err = store.OpenStore(context.Background(), indexPath, primary, defaultIndexSizeBits, defaultIndexFileSize, defaultSyncInterval, defaultBurstRate, defaultGCInterval, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, s.Close()) })
 

--- a/storethehash.go
+++ b/storethehash.go
@@ -75,7 +75,7 @@ func GCInterval(gcInterval time.Duration) Option {
 }
 
 // OpenHashedBlockstore opens a HashedBlockstore with the default index size
-func OpenHashedBlockstore(indexPath string, dataPath string, options ...Option) (*HashedBlockstore, error) {
+func OpenHashedBlockstore(ctx context.Context, indexPath string, dataPath string, options ...Option) (*HashedBlockstore, error) {
 	co := configOptions{
 		indexSizeBits: defaultIndexSizeBits,
 		indexFileSize: defaultIndexFileSize,
@@ -90,7 +90,7 @@ func OpenHashedBlockstore(indexPath string, dataPath string, options ...Option) 
 	if err != nil {
 		return nil, err
 	}
-	store, err := store.OpenStore(indexPath, primary, co.indexSizeBits, co.indexFileSize, co.syncInterval, co.burstRate, co.gcInterval, true)
+	store, err := store.OpenStore(ctx, indexPath, primary, co.indexSizeBits, co.indexFileSize, co.syncInterval, co.burstRate, co.gcInterval, true)
 	if err != nil {
 		return nil, err
 	}

--- a/storethehash_test.go
+++ b/storethehash_test.go
@@ -27,7 +27,7 @@ func TestParallelism(t *testing.T) {
 	dataPath := filepath.Join(tempDir, "storethehash.data")
 
 	t.Logf("Creating store in directory %s\n", tempDir)
-	bs, err := storethehash.OpenHashedBlockstore(indexPath, dataPath)
+	bs, err := storethehash.OpenHashedBlockstore(ctx, indexPath, dataPath)
 	require.NoError(t, err)
 	bs.Start()
 	defer bs.Close()

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.1.8"
+  "version": "v0.1.9"
 }


### PR DESCRIPTION
On startup, scanning or upgrading index files can take a long time and it may be necessary to cancel this process. This PR provides a context.Context to do this.

Fixes #51 