### PR TITLE
Fix a data race and data loss error in flush

### DIFF
--- a/store/index/index.go
+++ b/store/index/index.go
@@ -328,7 +328,10 @@ func scanIndexFile(ctx context.Context, basePath string, fileNum uint32, buckets
 				log.Errorw("Unexpected EOF scanning index", "file", indexPath)
 				file.Close()
 				// Cut off incomplete data
-				os.Truncate(indexPath, iterPos)
+				e := os.Truncate(indexPath, iterPos)
+				if e != nil {
+					log.Errorw("Error truncating file", "err", e, "file", indexPath)
+				}
 				break
 			}
 			return err
@@ -349,7 +352,10 @@ func scanIndexFile(ctx context.Context, basePath string, fileNum uint32, buckets
 				log.Errorw("Unexpected EOF scanning index record", "file", indexPath)
 				file.Close()
 				// Cut off incomplete data
-				os.Truncate(indexPath, pos-sizePrefixSize)
+				e := os.Truncate(indexPath, pos-sizePrefixSize)
+				if e != nil {
+					log.Errorw("Error truncating file", "err", e, "file", indexPath)
+				}
 				break
 			}
 			return err

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -567,4 +567,6 @@ func TestFlushRace(t *testing.T) {
 		err := <-errs
 		require.NoError(t, err)
 	}
+
+	require.NoError(t, i.Close())
 }

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -570,3 +570,42 @@ func TestFlushRace(t *testing.T) {
 
 	require.NoError(t, i.Close())
 }
+
+func TestFlushExcess(t *testing.T) {
+	const goroutines = 64
+	key1 := []byte{1, 2, 3, 4, 5, 6, 9, 9, 9, 9}
+	key2 := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	key3 := []byte{1, 2, 3, 4, 5, 6, 9, 8, 8, 8}
+
+	primaryStorage := inmemory.NewInmemory([][2][]byte{
+		{key1, {0x10}},
+		{key2, {0x20}},
+		{key3, {0x30}},
+	})
+	tempDir := t.TempDir()
+	indexPath := filepath.Join(tempDir, "storethehash.index")
+	i, err := OpenIndex(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0)
+	require.NoError(t, err)
+	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
+	require.NoError(t, err)
+	err = i.Put(key2, types.Block{Offset: 1, Size: 1})
+	require.NoError(t, err)
+
+	work, err := i.Flush()
+	require.NoError(t, err)
+	require.NotZero(t, work)
+
+	err = i.Put(key3, types.Block{Offset: 2, Size: 1})
+	require.NoError(t, err)
+
+	work, err = i.Flush()
+	require.NoError(t, err)
+	require.NotZero(t, work)
+
+	// Another flush with no new data should not do work.
+	work, err = i.Flush()
+	require.NoError(t, err)
+	require.Zero(t, work)
+
+	require.NoError(t, i.Close())
+}

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -572,7 +572,6 @@ func TestFlushRace(t *testing.T) {
 }
 
 func TestFlushExcess(t *testing.T) {
-	const goroutines = 64
 	key1 := []byte{1, 2, 3, 4, 5, 6, 9, 9, 9, 9}
 	key2 := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	key3 := []byte{1, 2, 3, 4, 5, 6, 9, 8, 8, 8}

--- a/store/primary/cid/cid_test.go
+++ b/store/primary/cid/cid_test.go
@@ -163,7 +163,6 @@ func TestFlushRace(t *testing.T) {
 }
 
 func TestFlushExcess(t *testing.T) {
-	const goroutines = 64
 	tempDir := t.TempDir()
 	primaryPath := filepath.Join(tempDir, "storethehash.primary")
 	primaryStorage, err := cidprimary.OpenCIDPrimary(primaryPath)

--- a/store/primary/cid/cid_test.go
+++ b/store/primary/cid/cid_test.go
@@ -129,3 +129,35 @@ func TestIndexGet(t *testing.T) {
 	err = primaryStorage.Close()
 	require.NoError(t, err)
 }
+
+func TestFlushRace(t *testing.T) {
+	const goroutines = 64
+	tempDir := t.TempDir()
+	primaryPath := filepath.Join(tempDir, "storethehash.primary")
+	primaryStorage, err := cidprimary.OpenCIDPrimary(primaryPath)
+	require.NoError(t, err)
+
+	// load blocks
+	blks := testutil.GenerateBlocksOfSize(5, 100)
+	for _, blk := range blks {
+		_, err := primaryStorage.Put(blk.Cid().Bytes(), blk.RawData())
+		require.NoError(t, err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error)
+	for n := 0; n < goroutines; n++ {
+		go func() {
+			<-start
+			_, err := primaryStorage.Flush()
+			errs <- err
+		}()
+	}
+	close(start)
+	for n := 0; n < goroutines; n++ {
+		err := <-errs
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, primaryStorage.Close())
+}

--- a/store/primary/multihash/multihash_test.go
+++ b/store/primary/multihash/multihash_test.go
@@ -158,4 +158,6 @@ func TestFlushRace(t *testing.T) {
 		err := <-errs
 		require.NoError(t, err)
 	}
+
+	require.NoError(t, primaryStorage.Close())
 }

--- a/store/primary/multihash/multihash_test.go
+++ b/store/primary/multihash/multihash_test.go
@@ -137,11 +137,9 @@ func TestFlushRace(t *testing.T) {
 
 	// load blocks
 	blks := testutil.GenerateBlocksOfSize(5, 100)
-	var locs []types.Block
 	for _, blk := range blks {
-		loc, err := primaryStorage.Put(blk.Cid().Hash(), blk.RawData())
+		_, err := primaryStorage.Put(blk.Cid().Hash(), blk.RawData())
 		require.NoError(t, err)
-		locs = append(locs, loc)
 	}
 
 	start := make(chan struct{})

--- a/store/primary/multihash/multihash_test.go
+++ b/store/primary/multihash/multihash_test.go
@@ -161,7 +161,6 @@ func TestFlushRace(t *testing.T) {
 }
 
 func TestFlushExcess(t *testing.T) {
-	const goroutines = 64
 	tempDir := t.TempDir()
 	primaryPath := filepath.Join(tempDir, "storethehash.primary")
 	primaryStorage, err := mhprimary.OpenMultihashPrimary(primaryPath)

--- a/store/primary/multihash/multihash_test.go
+++ b/store/primary/multihash/multihash_test.go
@@ -159,3 +159,39 @@ func TestFlushRace(t *testing.T) {
 
 	require.NoError(t, primaryStorage.Close())
 }
+
+func TestFlushExcess(t *testing.T) {
+	const goroutines = 64
+	tempDir := t.TempDir()
+	primaryPath := filepath.Join(tempDir, "storethehash.primary")
+	primaryStorage, err := mhprimary.OpenMultihashPrimary(primaryPath)
+	require.NoError(t, err)
+
+	// load blocks
+	blks := testutil.GenerateBlocksOfSize(5, 100)
+	for _, blk := range blks {
+		_, err := primaryStorage.Put(blk.Cid().Hash(), blk.RawData())
+		require.NoError(t, err)
+	}
+
+	work, err := primaryStorage.Flush()
+	require.NoError(t, err)
+	require.NotZero(t, work)
+
+	blks = testutil.GenerateBlocksOfSize(5, 100)
+	for _, blk := range blks {
+		_, err := primaryStorage.Put(blk.Cid().Hash(), blk.RawData())
+		require.NoError(t, err)
+	}
+
+	work, err = primaryStorage.Flush()
+	require.NoError(t, err)
+	require.NotZero(t, work)
+
+	// Another flush with no new data should not do work.
+	work, err = primaryStorage.Flush()
+	require.NoError(t, err)
+	require.Zero(t, work)
+
+	require.NoError(t, primaryStorage.Close())
+}


### PR DESCRIPTION
There are two pools, one to flush (`curPool`) and one to update (`nextPool`). When `Flush` is called these pools are swapped and the items in `curPool` are written to disk.  This pertains to the index, primary, and freelist.

### Race:
If there are concurrent calls to `Flush`, the 2nd `Flush` can swap the pools while the 1st `Flush` is still reading the pool being flushed. That could cause the pool being read by the 1st `Flush` to be written to concurrently. This is fixed by only allowing one `Flush` at a time.

A second race was present between concurrent `Flush` and `Sync`, since `Sync` could reset the `curPool` while `Flush` was still reading it. This is fixed by resetting the `curPool` only in `Flush`.

### Data Loss:
`Flush` swapped the pools and flushed `curPool`, and did not reset either pool. Having already flushed data in the update pool caused subsequent calls to `Flush` to unnecessarily write that data to disk again. Swapping pools and retaining old data may also cause data loss if there is a newer version of the same data in the other pool; flushing the pool with the older data may replace the newer data. This is fixed by not swapping the pools, and instead creating a new pool for new updates to be written to

NOTE: Both of these issues were present for all history of storethehash. These problems were mostly avoided by automatically `Flush` at the store level explicitly or automatically, which callis `Sync` and resets `curPool`. Concurrent calls to `Flush` could still have caused problems.