### PR TITLE
Improve StorageSize API

### DIFF
--- a/store/freelist/freelist.go
+++ b/store/freelist/freelist.go
@@ -156,3 +156,16 @@ func (cpi *FreeListIter) Next() (*types.Block, error) {
 	size := binary.LittleEndian.Uint32(sizeBuf)
 	return &types.Block{Size: types.Size(size), Offset: types.Position(offset)}, nil
 }
+
+// StorageSize returns bytes of storage used by the freelist.
+func (fl *FreeList) StorageSize() (int64, error) {
+	fi, err := fl.file.Stat()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	return fi.Size(), nil
+}

--- a/store/index/index.go
+++ b/store/index/index.go
@@ -264,34 +264,24 @@ func scanIndex(ctx context.Context, basePath string, fileNum uint32, buckets Buc
 	return lastFileNum, nil
 }
 
-// StorageSize returns bytes of storage used by the index and freelist files.
-func (i *Index) StorageSize() (int64, error) {
-	header, err := readHeader(i.headerPath)
+// StorageSize returns bytes of storage used by the index files.
+func (index *Index) StorageSize() (int64, error) {
+	header, err := readHeader(index.headerPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return 0, nil
 		}
 		return 0, err
 	}
-	var size int64
-	fi, err := os.Stat(i.headerPath)
+	fi, err := os.Stat(index.headerPath)
 	if err != nil {
 		return 0, err
 	}
-	size += fi.Size()
-
-	fi, err = os.Stat(i.basePath + ".free")
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return 0, err
-		}
-	} else {
-		size += fi.Size()
-	}
+	size := fi.Size()
 
 	fileNum := header.FirstFile
 	for {
-		fi, err = os.Stat(indexFileName(i.basePath, fileNum))
+		fi, err = os.Stat(indexFileName(index.basePath, fileNum))
 		if err != nil {
 			if os.IsNotExist(err) {
 				break

--- a/store/primary/cid/cid.go
+++ b/store/primary/cid/cid.go
@@ -255,4 +255,12 @@ func (cpi *CIDPrimaryIter) Next() ([]byte, []byte, error) {
 	return c.Bytes(), value, err
 }
 
+func (cp *CIDPrimary) StorageSize() (int64, error) {
+	fi, err := cp.file.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}
+
 var _ primary.PrimaryStorage = &CIDPrimary{}

--- a/store/primary/inmemory/inmemory.go
+++ b/store/primary/inmemory/inmemory.go
@@ -79,4 +79,8 @@ func (imi *inMemoryIter) Next() ([]byte, []byte, error) {
 	return key, value, nil
 }
 
+func (im *InMemory) StorageSize() (int64, error) {
+	return 0, nil
+}
+
 var _ primary.PrimaryStorage = &InMemory{}

--- a/store/primary/multihash/multihash.go
+++ b/store/primary/multihash/multihash.go
@@ -265,4 +265,12 @@ func (cpi *MultihashPrimaryIter) Next() ([]byte, []byte, error) {
 	return h, value, err
 }
 
+func (cp *MultihashPrimary) StorageSize() (int64, error) {
+	fi, err := cp.file.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}
+
 var _ primary.PrimaryStorage = &MultihashPrimary{}

--- a/store/primary/primary.go
+++ b/store/primary/primary.go
@@ -30,6 +30,8 @@ type PrimaryStorage interface {
 	Close() error
 	OutstandingWork() types.Work
 	Iter() (PrimaryStorageIter, error)
+
+	StorageSize() (int64, error)
 }
 
 type PrimaryStorageIter interface {

--- a/store/store.go
+++ b/store/store.go
@@ -489,8 +489,34 @@ func (s *Store) GetSize(key []byte) (types.Size, bool, error) {
 	return blk.Size - types.Size(len(key)), true, nil
 }
 
-// IndexStorageSize returns the storage used by the index files. This includes
-// the `.info` file and the `.free` file and does not include primary storage.
+// IndexStorageSize returns the storage used by the index files.
 func (s *Store) IndexStorageSize() (int64, error) {
 	return s.index.StorageSize()
+}
+
+// PrimaryStorageSize returns the storage used by the primary storage files.
+func (s *Store) PrimaryStorageSize() (int64, error) {
+	return s.index.Primary.StorageSize()
+}
+
+// FreelistStorageSize returns the storage used by the freelist files.
+func (s *Store) FreelistStorageSize() (int64, error) {
+	return s.freelist.StorageSize()
+}
+
+// StorageSize returns the storage used by the index, primary, and freelist files.
+func (s *Store) StorageSize() (int64, error) {
+	isize, err := s.index.StorageSize()
+	if err != nil {
+		return 0, err
+	}
+	psize, err := s.index.Primary.StorageSize()
+	if err != nil {
+		return 0, err
+	}
+	fsize, err := s.freelist.StorageSize()
+	if err != nil {
+		return 0, err
+	}
+	return isize + psize + fsize, nil
 }


### PR DESCRIPTION
This makes it clear what size if being returned, by having each component (e.g. freelist, primary) give its own storage size, and the store giving the sum for all components.