### PR TITLE
Do not uses in-memory size buckets

### DIFF
--- a/store/index/buckets.go
+++ b/store/index/buckets.go
@@ -35,34 +35,3 @@ func (b Buckets) Get(index BucketIndex) (types.Position, error) {
 	}
 	return b[int(index)], nil
 }
-
-// SizeBuckets contains sizes for all record lists
-//
-// The generic specifies how many bits are used to create the buckets. The number of buckets is
-// 2 ^ bits.
-type SizeBuckets []types.Size
-
-// NewSizeBuckets returns a list of buckets for the given index size in bits
-func NewSizeBuckets(indexSizeBits uint8) (SizeBuckets, error) {
-	if indexSizeBits > 32 {
-		return nil, types.ErrIndexTooLarge
-	}
-	return make(SizeBuckets, 1<<indexSizeBits), nil
-}
-
-// Put updates a bucket value
-func (b SizeBuckets) Put(index BucketIndex, offset types.Size) error {
-	if int(index) > len(b)-1 {
-		return types.ErrOutOfBounds
-	}
-	b[int(index)] = offset
-	return nil
-}
-
-// Get updates returns the value at the given index
-func (b SizeBuckets) Get(index BucketIndex) (types.Size, error) {
-	if int(index) > len(b)-1 {
-		return 0, types.ErrOutOfBounds
-	}
-	return b[int(index)], nil
-}

--- a/store/index/gc_test.go
+++ b/store/index/gc_test.go
@@ -74,9 +74,7 @@ func TestGC(t *testing.T) {
 	bucketY := 7143210
 	bucketZ := 12228148
 	idx.buckets[bucketY] = 0
-	idx.sizeBuckets[bucketY] = 0
 	idx.buckets[bucketZ] = 0
-	idx.sizeBuckets[bucketZ] = 0
 
 	recordSize := int64(18 + sizePrefixSize)
 
@@ -103,9 +101,7 @@ func TestGC(t *testing.T) {
 	bucketY = 719032
 	bucketZ = 5851659
 	idx.buckets[bucketY] = 0
-	idx.sizeBuckets[bucketY] = 0
 	idx.buckets[bucketZ] = 0
-	idx.sizeBuckets[bucketZ] = 0
 
 	sizeBefore = fi.Size()
 

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -473,7 +473,6 @@ func TestIndexGet(t *testing.T) {
 
 	// Check that both indexes have same buckets.
 	require.Equal(t, i.buckets, i2.buckets)
-	require.Equal(t, i.sizeBuckets, i2.sizeBuckets)
 }
 
 func TestIndexHeader(t *testing.T) {

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.2.1"
+  "version": "v0.2.2"
 }


### PR DESCRIPTION
The size buckets were being used in exactly one place, that is, when reading the record list from an index file. The size of the record is already present at the place where that data is read, so read it from there instead of keeping the size in memory.

Removing the size buckets saves considerable memory (2 ^ bitPrefxSize) * 4 bytes at no detectable cost to performance.
