### PR TITLE
Replace GCFastScan option with simple heuristic

### DIFF
--- a/store/index/gc_test.go
+++ b/store/index/gc_test.go
@@ -26,7 +26,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, err)
 	defer primary.Close()
 
-	idx, err := Open(context.Background(), indexPath, primary, 24, 1024, 0, 0, true)
+	idx, err := Open(context.Background(), indexPath, primary, 24, 1024, 0, 0)
 	require.NoError(t, err)
 	defer idx.Close()
 
@@ -49,7 +49,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, RemoveSavedBuckets(indexPath))
 
 	// Open the index with the duplicated files.
-	idx, err = Open(context.Background(), indexPath, primary, 24, 1024, 0, 0, false)
+	idx, err = Open(context.Background(), indexPath, primary, 24, 1024, 0, 0)
 	require.NoError(t, err)
 	defer idx.Close()
 
@@ -88,7 +88,7 @@ func TestGC(t *testing.T) {
 	t.Log("File size before truncation:", sizeBefore)
 
 	// Run GC and check that second to last file was truncated by two records.
-	count, freeCount, err = idx.gc(context.Background(), true)
+	count, _, err = idx.gc(context.Background(), false)
 	require.NoError(t, err)
 	require.Equal(t, count, 0)
 
@@ -127,10 +127,9 @@ func TestGC(t *testing.T) {
 	t.Log("Record size before:", size1Before)
 
 	// Run GC and check that first and second records were merged into one free record.
-	count, freeCount, err = idx.gc(context.Background(), true)
+	count, _, err = idx.gc(context.Background(), false)
 	require.NoError(t, err)
 	require.Zero(t, count)
-	require.Zero(t, freeCount)
 
 	fi, err = os.Stat(fileName)
 	require.NoError(t, err)

--- a/store/index/index.go
+++ b/store/index/index.go
@@ -151,7 +151,7 @@ type bucketPool map[BucketIndex][]byte
 //
 // Specifying 0 for indexSizeBits and maxFileSize results in using their
 // default values. A gcInterval of 0 disables garbage collection.
-func Open(ctx context.Context, path string, primary primary.PrimaryStorage, indexSizeBits uint8, maxFileSize uint32, gcInterval, gcTimeLimit time.Duration, gcFastScan bool) (*Index, error) {
+func Open(ctx context.Context, path string, primary primary.PrimaryStorage, indexSizeBits uint8, maxFileSize uint32, gcInterval, gcTimeLimit time.Duration) (*Index, error) {
 	var file *os.File
 	headerPath := filepath.Clean(path) + ".info"
 
@@ -243,7 +243,7 @@ func Open(ctx context.Context, path string, primary primary.PrimaryStorage, inde
 	} else {
 		idx.updateSig = make(chan struct{}, 1)
 		idx.gcDone = make(chan struct{})
-		go idx.garbageCollector(gcInterval, gcTimeLimit, gcFastScan)
+		go idx.garbageCollector(gcInterval, gcTimeLimit)
 	}
 
 	return idx, nil

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -40,7 +40,7 @@ func assertCommonPrefixTrimmed(t *testing.T, key1 []byte, key2 []byte, expectedK
 	primaryStorage := inmemory.New([][2][]byte{{key1, {0x20}}, {key2, {0x30}}})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestIndexPutSingleKey(t *testing.T) {
 	primaryStorage := inmemory.New([][2][]byte{})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	err = i.Put([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, types.Block{Offset: 222, Size: 10})
 	require.NoError(t, err)
@@ -137,7 +137,7 @@ func TestIndexRemoveKey(t *testing.T) {
 	primaryStorage := inmemory.New([][2][]byte{})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	// Put key 1
 	err = i.Put(k1, b1)
@@ -205,7 +205,7 @@ func TestIndexPutDistinctKey(t *testing.T) {
 	primaryStorage := inmemory.New([][2][]byte{})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	err = i.Put([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, types.Block{Offset: 222, Size: 10})
 	require.NoError(t, err)
@@ -248,7 +248,7 @@ func TestCorrectCacheReading(t *testing.T) {
 	primaryStorage := inmemory.New([][2][]byte{})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	// put key in, then flush the cache
 	err = i.Put([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, types.Block{Offset: 222, Size: 10})
@@ -301,7 +301,7 @@ func TestIndexPutPrevAndNextKeyCommonPrefix(t *testing.T) {
 	})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
 	require.NoError(t, err)
@@ -347,7 +347,7 @@ func TestIndexGetEmptyIndex(t *testing.T) {
 	primaryStorage := inmemory.New([][2][]byte{})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	index, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	index, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	_, found, err := index.Get(key)
 	require.NoError(t, err)
@@ -368,7 +368,7 @@ func TestIndexGet(t *testing.T) {
 	})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
 	require.NoError(t, err)
@@ -435,7 +435,7 @@ func TestIndexGet(t *testing.T) {
 
 	err = i.Close()
 	require.NoError(t, err)
-	i, err = Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i, err = Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 
 	// same should hold true when index is closed and reopened
@@ -461,13 +461,13 @@ func TestIndexGet(t *testing.T) {
 	require.FileExists(t, bucketsFileName)
 
 	// Open index reading bucket state.
-	i, err = Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i, err = Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	t.Cleanup(func() { i.Close() })
 	require.NoFileExists(t, bucketsFileName)
 
 	// Open index scanning index files.
-	i2, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i2, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	t.Cleanup(func() { i2.Close() })
 
@@ -480,13 +480,13 @@ func TestIndexHeader(t *testing.T) {
 	indexPath := filepath.Join(tempDir, "storethehash.index")
 
 	primaryStorage := inmemory.New([][2][]byte{})
-	i1, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i1, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	t.Cleanup(func() { i1.Close() })
 	assertHeader(t, i1.headerPath, bucketBits)
 
 	// Check that the header doesn't change if the index is opened again.
-	i2, err := Open(context.Background(), indexPath, inmemory.New([][2][]byte{}), bucketBits, fileSize, 0, 0, false)
+	i2, err := Open(context.Background(), indexPath, inmemory.New([][2][]byte{}), bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	t.Cleanup(func() { i2.Close() })
 	assertHeader(t, i2.headerPath, bucketBits)
@@ -506,7 +506,7 @@ func TestIndexGetBad(t *testing.T) {
 
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, 0, 0, 0, false)
+	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, 0, 0, 0)
 
 	require.NoError(t, err)
 	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
@@ -563,7 +563,7 @@ func TestFlushRace(t *testing.T) {
 	})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
 	require.NoError(t, err)
@@ -602,7 +602,7 @@ func TestFlushExcess(t *testing.T) {
 	})
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
-	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0, false)
+	i, err := Open(context.Background(), indexPath, primaryStorage, bucketBits, fileSize, 0, 0)
 	require.NoError(t, err)
 	err = i.Put(key1, types.Block{Offset: 0, Size: 1})
 	require.NoError(t, err)

--- a/store/option.go
+++ b/store/option.go
@@ -13,7 +13,6 @@ const (
 	defaultSyncInterval  = time.Second
 	defaultGCInterval    = 30 * time.Minute
 	defaultGCTimeLimit   = 5 * time.Minute
-	defaultGCFastScan    = true
 )
 
 type config struct {
@@ -23,7 +22,6 @@ type config struct {
 	burstRate     types.Work
 	gcInterval    time.Duration
 	gcTimeLimit   time.Duration
-	gcFastScan    bool
 }
 
 type Option func(*config)
@@ -76,13 +74,5 @@ func GCInterval(gcInterval time.Duration) Option {
 func GCTimeLimit(gcTimeLimit time.Duration) Option {
 	return func(c *config) {
 		c.gcTimeLimit = gcTimeLimit
-	}
-}
-
-// GCFastScan enables a fast scan of files to find any that are not referenced
-// by any index buckets.
-func GCFastScan(fastScan bool) Option {
-	return func(c *config) {
-		c.gcFastScan = fastScan
 	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -51,11 +51,10 @@ func OpenStore(ctx context.Context, path string, primary primary.PrimaryStorage,
 		burstRate:     defaultBurstRate,
 		gcInterval:    defaultGCInterval,
 		gcTimeLimit:   defaultGCTimeLimit,
-		gcFastScan:    defaultGCFastScan,
 	}
 	c.apply(options)
 
-	index, err := index.Open(ctx, path, primary, c.indexSizeBits, c.indexFileSize, c.gcInterval, c.gcTimeLimit, c.gcFastScan)
+	index, err := index.Open(ctx, path, primary, c.indexSizeBits, c.indexFileSize, c.gcInterval, c.gcTimeLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.2.5"
+  "version": "v0.2.6"
 }


### PR DESCRIPTION
Remove the option to enable/disable iterating buckets to find and truncate free index files. Instead, use a simple heuristic to determine if it should run.
