### PR TITLE
GC resumes where it stopped at timeout

### DIFF
--- a/store/index/gc.go
+++ b/store/index/gc.go
@@ -49,10 +49,12 @@ func (index *Index) garbageCollector(interval, timeLimit time.Duration) {
 				rmCount, freeCount, err := index.gc(ctx, timeLimit, freeSkip == 0)
 				switch err {
 				case nil:
-					// GC finished, so do not run truncateFreeFiles next
-					// time since it will probably not be helpful if GC has
-					// time to finish.
-					freeCount = 0
+					if !index.gcResume {
+						// GC had time to reap records from all files, so
+						// running truncateFreeFiles will not be helpful over
+						// just reaping records on next GC run.
+						freeCount = 0
+					}
 					log.Infof("GC finished, removed %d index files", rmCount)
 				case context.Canceled:
 					log.Info("GC canceled")

--- a/store/index/gc.go
+++ b/store/index/gc.go
@@ -123,7 +123,7 @@ func (index *Index) gc(ctx context.Context, timeLimit time.Duration, scanFree bo
 	if index.gcResume {
 		firstFileNum = index.gcResumeAt
 		index.gcResume = false
-		log.Info("Resuming GC at file %d", firstFileNum)
+		log.Infow("Resuming GC", "file", filepath.Base(indexFileName(index.basePath, firstFileNum)))
 	} else {
 		firstFileNum = header.FirstFile
 	}
@@ -135,11 +135,8 @@ func (index *Index) gc(ctx context.Context, timeLimit time.Duration, scanFree bo
 		stale, err := index.gcIndexFile(ctx, fileNum, indexPath)
 		if err != nil {
 			if err == context.DeadlineExceeded {
-				fileNum++
-				if fileNum != lastFileNum {
-					index.gcResumeAt = fileNum
-					index.gcResume = true
-				}
+				index.gcResumeAt = fileNum
+				index.gcResume = true
 				log.Infow("GC stopped at time limit", "limit", timeLimit)
 				return count, freeCount, nil
 			}

--- a/store/index/gc.go
+++ b/store/index/gc.go
@@ -25,14 +25,13 @@ const maxFreeSkip = 8
 func (index *Index) garbageCollector(interval, timeLimit time.Duration) {
 	defer close(index.gcDone)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	var gcDone chan struct{}
 	var freeSkip, freeSkipIncr int
 
-	// Run 1st GC 1 minute after startup.
-	t := time.NewTimer(time.Minute)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	t := time.NewTimer(interval)
 
 	for {
 		select {

--- a/store/index/gc_test.go
+++ b/store/index/gc_test.go
@@ -31,7 +31,7 @@ func TestGC(t *testing.T) {
 	defer idx.Close()
 
 	// All index files in use, so gc should not remove any files.
-	count, freeCount, err := idx.gc(context.Background(), true)
+	count, freeCount, err := idx.gc(context.Background(), 0, true)
 	require.NoError(t, err)
 	require.Zero(t, count)
 	require.Zero(t, freeCount)
@@ -54,13 +54,13 @@ func TestGC(t *testing.T) {
 	defer idx.Close()
 
 	// GC should now remove the first 2 files only.
-	count, freeCount, err = idx.gc(context.Background(), true)
+	count, freeCount, err = idx.gc(context.Background(), 0, true)
 	require.NoError(t, err)
 	require.Equal(t, 2, count)
 	require.Equal(t, 2, freeCount)
 
 	// Another GC should not remove files.
-	count, freeCount, err = idx.gc(context.Background(), true)
+	count, freeCount, err = idx.gc(context.Background(), 0, true)
 	require.NoError(t, err)
 	require.Zero(t, count)
 	require.Zero(t, freeCount)
@@ -88,7 +88,7 @@ func TestGC(t *testing.T) {
 	t.Log("File size before truncation:", sizeBefore)
 
 	// Run GC and check that second to last file was truncated by two records.
-	count, _, err = idx.gc(context.Background(), false)
+	count, _, err = idx.gc(context.Background(), 0, false)
 	require.NoError(t, err)
 	require.Equal(t, count, 0)
 
@@ -127,7 +127,7 @@ func TestGC(t *testing.T) {
 	t.Log("Record size before:", size1Before)
 
 	// Run GC and check that first and second records were merged into one free record.
-	count, _, err = idx.gc(context.Background(), false)
+	count, _, err = idx.gc(context.Background(), 0, false)
 	require.NoError(t, err)
 	require.Zero(t, count)
 

--- a/store/index/index.go
+++ b/store/index/index.go
@@ -140,7 +140,9 @@ type Index struct {
 	basePath          string
 	updateSig         chan struct{}
 
-	gcDone chan struct{}
+	gcDone     chan struct{}
+	gcResumeAt uint32
+	gcResume   bool
 }
 
 type bucketPool map[BucketIndex][]byte

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.2.6"
+  "version": "v0.2.7"
 }


### PR DESCRIPTION
This allows GC to spend less time re-traversing files that it has already reaped records from with few additional records to reap. This means GC does more in the time is it given t run.

- Do not handle timeout as an error since that prevents stats from being used.