### PR TITLE
WIP: disable fsync. don't merge, it's for testing only

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -395,16 +395,18 @@ func (s *Store) commit() (types.Work, error) {
 	if err != nil {
 		return 0, err
 	}
-	// finalize disk writes
-	if err = s.index.Primary.Sync(); err != nil {
-		return 0, err
-	}
-	if err = s.index.Sync(); err != nil {
-		return 0, err
-	}
-	if err = s.freelist.Sync(); err != nil {
-		return 0, err
-	}
+	// NOTE vmx 2022-09-07: Try out what the performance look like if no
+	// fsyncs are happening.
+	//// finalize disk writes
+	//if err = s.index.Primary.Sync(); err != nil {
+	//	return 0, err
+	//}
+	//if err = s.index.Sync(); err != nil {
+	//	return 0, err
+	//}
+	//if err = s.freelist.Sync(); err != nil {
+	//	return 0, err
+	//}
 	return primaryWork + indexWork + flWork, nil
 }
 


### PR DESCRIPTION
I suspect that the performance difference between Pebble and store-the-hash is due to different ways of fsyncing things. Hence I comment the fsyncs out in this PR to see what the performance does.