### PR TITLE
Use LRU file cache for reading index files

### DIFF
--- a/store/filecache/filecache.go
+++ b/store/filecache/filecache.go
@@ -39,6 +39,9 @@ func New(capacity int) *FileCache {
 // NewOpenFile created a new FileCache that opens files using the specified
 // arguments to os.OpenFile.
 func NewOpenFile(capacity int, openFlag int, openPerm os.FileMode) *FileCache {
+	if capacity < 0 {
+		capacity = 0
+	}
 	return &FileCache{
 		capacity: capacity,
 		openFlag: openFlag,
@@ -164,6 +167,10 @@ func (c *FileCache) Remove(name string) {
 }
 
 func (c *FileCache) SetCacheSize(capacity int) {
+	if capacity < 0 {
+		capacity = 0
+	}
+
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/store/filecache/filecache.go
+++ b/store/filecache/filecache.go
@@ -1,0 +1,190 @@
+// Package filecache provides an LRU cache of opened files. If the same files
+// are frequently opened and closed this is useful for reducing the number of
+// syscalls for opening and closing the files.
+package filecache
+
+import (
+	"container/list"
+	"errors"
+	"os"
+	"sync"
+)
+
+type FileCache struct {
+	cache     map[string]*list.Element
+	capacity  int
+	ll        *list.List
+	lock      sync.Mutex
+	onEvicted func(*os.File, int)
+	openFlag  int
+	openPerm  os.FileMode
+	removed   map[string]*entry
+}
+
+var ErrAlreadyClosed = errors.New("already closed")
+
+type entry struct {
+	file *os.File
+	refs int
+}
+
+// New creates a new FileCache that can hold up to specified capacity of open
+// files. If capacity is 0, then there is no limit. Files are opened read-only.
+// If other open flags and permissions are needed, use NewOpenFile.
+func New(capacity int) *FileCache {
+	return NewOpenFile(capacity, os.O_RDONLY, 0)
+}
+
+// NewOpenFile created a new FileCache that opens files using the specified
+// arguments to os.OpenFile.
+func NewOpenFile(capacity int, openFlag int, openPerm os.FileMode) *FileCache {
+	return &FileCache{
+		capacity: capacity,
+		openFlag: openFlag,
+		openPerm: openPerm,
+	}
+}
+
+// Open returns the already opened file, or opens the named file and returns
+// that. The file is subsequently retrievable without opening it again, unless
+// it has been removed from the FileCache.
+//
+// Every call to Open must be accompanied by a call to Close. Otherwise,
+// reference counts will not be adjusted correctly and file handles will leak.
+func (c *FileCache) Open(name string) (*os.File, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.cache == nil {
+		c.cache = make(map[string]*list.Element)
+		c.ll = list.New()
+	}
+
+	if elem, ok := c.cache[name]; ok {
+		c.ll.MoveToFront(elem)
+		ent := elem.Value.(*entry)
+		ent.refs++
+		return ent.file, nil
+	}
+
+	file, err := os.OpenFile(name, c.openFlag, c.openPerm)
+	if err != nil {
+		return nil, err
+	}
+
+	c.cache[name] = c.ll.PushFront(&entry{file, 1})
+	if c.capacity != 0 && c.ll.Len() > c.capacity {
+		c.removeOldest()
+	}
+
+	return file, nil
+}
+
+// Close decrements the reference count on the file. If the file has been
+// removed from the cache and the reference count is zero, then the file is
+// closed.
+func (c *FileCache) Close(file *os.File) error {
+	name := file.Name()
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if elem, ok := c.cache[name]; ok {
+		ent := elem.Value.(*entry)
+		if ent.refs == 0 {
+			return ErrAlreadyClosed
+		}
+		ent.refs--
+		return nil
+	}
+	// File is no longer in cache, see if it was removed.
+	ent, ok := c.removed[name]
+	if !ok {
+		return ErrAlreadyClosed
+	}
+
+	if ent.refs == 1 {
+		delete(c.removed, name)
+		if len(c.removed) == 0 {
+			c.removed = nil
+		}
+		return file.Close()
+	}
+
+	// Removed from cache, but still in use.
+	ent.refs--
+	return nil
+}
+
+// Len return the number of open files in the FileCache.
+func (c *FileCache) Len() int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.cache == nil {
+		return 0
+	}
+	return c.ll.Len()
+}
+
+// Clear closes and removes all files in the FileCache.
+func (c *FileCache) Clear() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.cache == nil {
+		return
+	}
+
+	for _, elem := range c.cache {
+		c.removeElement(elem)
+	}
+	c.ll = nil
+	c.cache = nil
+}
+
+func (c *FileCache) Remove(name string) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.cache == nil {
+		return nil
+	}
+	if elem, ok := c.cache[name]; ok {
+		return c.removeElement(elem)
+	}
+	return nil
+}
+
+func (c *FileCache) SetOnEvicted(f func(*os.File, int)) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.onEvicted = f
+}
+
+func (c *FileCache) removeOldest() error {
+	elem := c.ll.Back()
+	if elem != nil {
+		return c.removeElement(elem)
+	}
+	return nil
+}
+
+func (c *FileCache) removeElement(elem *list.Element) error {
+	c.ll.Remove(elem)
+	ent := elem.Value.(*entry)
+	delete(c.cache, ent.file.Name())
+	if c.onEvicted != nil {
+		c.onEvicted(ent.file, ent.refs)
+	}
+	if ent.refs == 0 {
+		return ent.file.Close()
+	}
+	// Removed from cache, but still in use.
+	if c.removed == nil {
+		c.removed = make(map[string]*entry)
+	}
+	c.removed[ent.file.Name()] = ent
+	return nil
+}

--- a/store/filecache/filecache_test.go
+++ b/store/filecache/filecache_test.go
@@ -59,7 +59,7 @@ func TestOpen(t *testing.T) {
 	require.NoError(t, fc.Close(fooFile))
 	require.NoError(t, fc.Close(fooFile))
 	err = fc.Close(fooFile)
-	require.ErrorIs(t, ErrAlreadyClosed, err)
+	require.ErrorContains(t, err, os.ErrClosed.Error())
 
 	err = fc.Remove(bazName)
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestOpen(t *testing.T) {
 	require.NoError(t, fc.Close(bazFile))
 
 	err = fc.Close(bazFile)
-	require.ErrorIs(t, ErrAlreadyClosed, err)
+	require.ErrorContains(t, err, os.ErrClosed.Error())
 }
 
 func TestMultiFileInstances(t *testing.T) {
@@ -163,7 +163,7 @@ func TestMultiFileInstances(t *testing.T) {
 
 	// Closing fooFileX again should result in error.
 	err = fc.Close(fooFileX)
-	require.ErrorIs(t, ErrAlreadyClosed, err)
+	require.ErrorContains(t, err, os.ErrClosed.Error())
 
 	// Make sure 3 closes are required to remove fooFile.
 	require.NoError(t, fc.Close(fooFile))
@@ -173,7 +173,7 @@ func TestMultiFileInstances(t *testing.T) {
 	require.NoError(t, fc.Close(fooFile))
 	require.Equal(t, 0, len(fc.removed))
 	err = fc.Close(fooFile)
-	require.ErrorIs(t, ErrAlreadyClosed, err)
+	require.ErrorContains(t, err, os.ErrClosed.Error())
 
 	// baz should still be in cache.
 	require.Equal(t, 1, fc.Len())
@@ -206,10 +206,10 @@ func TestZeroSize(t *testing.T) {
 	require.False(t, evicted)
 
 	require.Zero(t, fc.Len())
-	require.Equal(t, 2, len(fc.removed))
+	require.Zero(t, len(fc.removed))
 
 	require.NoError(t, fc.Close(file1))
-	require.Equal(t, 1, len(fc.removed))
+	require.Zero(t, len(fc.removed))
 
 	require.NoError(t, fc.Close(file2))
 	require.Zero(t, len(fc.removed))

--- a/store/filecache/filecache_test.go
+++ b/store/filecache/filecache_test.go
@@ -79,6 +79,9 @@ func TestOpen(t *testing.T) {
 
 	require.Zero(t, fc.Len())
 	require.Zero(t, len(fc.removed))
+
+	hits, misses, ln, cp := fc.Stats()
+	t.Logf("Cache stats: hits=%d misses=%d len=%d cap=%d", hits, misses, ln, cp)
 }
 
 func TestMultiFileInstances(t *testing.T) {
@@ -188,6 +191,11 @@ func TestMultiFileInstances(t *testing.T) {
 	fc.Clear()
 	require.Zero(t, fc.Len())
 	require.Zero(t, len(fc.removed))
+
+	hits, misses, ln, cp := fc.Stats()
+	require.Equal(t, 2, hits)
+	require.Equal(t, 4, misses)
+	t.Logf("Cache stats: hits=%d misses=%d len=%d cap=%d", hits, misses, ln, cp)
 }
 
 func TestZeroSize(t *testing.T) {

--- a/store/filecache/filecache_test.go
+++ b/store/filecache/filecache_test.go
@@ -1,0 +1,112 @@
+package filecache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpen(t *testing.T) {
+	var (
+		evictedCount int
+		evictedName  string
+		evictedRefs  int
+	)
+
+	fc := NewOpenFile(2, os.O_CREATE|os.O_RDWR, 0777)
+	fc.SetOnEvicted(func(file *os.File, refs int) {
+		t.Logf("Removed %q from cache", filepath.Base(file.Name()))
+		evictedCount++
+		evictedName = file.Name()
+		evictedRefs = refs
+	})
+
+	tmp := t.TempDir()
+	fooName := filepath.Join(tmp, "foo")
+	barName := filepath.Join(tmp, "bar")
+	bazName := filepath.Join(tmp, "baz")
+
+	fooFile, err := fc.Open(fooName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	barFile, err := fc.Open(barName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fooFile, err = fc.Open(fooName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if evictedCount != 0 {
+		t.Fatal("should not have evicted file")
+	}
+
+	bazFile, err := fc.Open(bazName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if evictedCount != 1 {
+		t.Fatal("should have evicted 1 file")
+	}
+	if evictedName != barName {
+		t.Fatalf("expected %s to be evicted, got %s", barName, evictedName)
+	}
+	if evictedRefs != 1 {
+		t.Fatalf("expected file to have ref count of 1, got %d", evictedRefs)
+	}
+
+	err = fc.Close(barFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	barFile, err = fc.Open(barName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if evictedCount != 2 {
+		t.Fatal("should have evicted 1 file")
+	}
+	if evictedName != fooName {
+		t.Fatalf("expected %s to be evicted, got %s", fooName, evictedName)
+	}
+	if evictedRefs != 2 {
+		t.Fatalf("expected file to have ref count of 1, got %d", evictedRefs)
+	}
+
+	if err = fc.Close(fooFile); err != nil {
+		t.Fatal(err)
+	}
+	if err = fc.Close(fooFile); err != nil {
+		t.Fatal(err)
+	}
+	if err = fc.Close(fooFile); err == nil {
+		t.Fatal("did not get expected err")
+	}
+
+	if err = fc.Remove(bazName); err != nil {
+		t.Fatal(err)
+	}
+	if evictedCount != 3 {
+		t.Fatal("should have evicted 1 file")
+	}
+	if evictedName != bazName {
+		t.Fatalf("expected %s to be evicted, got %s", fooName, evictedName)
+	}
+	if evictedRefs != 1 {
+		t.Fatalf("expected file to have ref count of 1, got %d", evictedRefs)
+	}
+	if err = fc.Close(bazFile); err != nil {
+		t.Fatal(err)
+	}
+	err = fc.Close(bazFile)
+	if err != ErrAlreadyClosed {
+		t.Fatal("expected error:", ErrAlreadyClosed)
+	}
+}

--- a/store/filecache/filecache_test.go
+++ b/store/filecache/filecache_test.go
@@ -72,6 +72,13 @@ func TestOpen(t *testing.T) {
 
 	err = fc.Close(bazFile)
 	require.ErrorContains(t, err, os.ErrClosed.Error())
+
+	// barFile closed, but still in cache, with zero references.
+	require.Equal(t, 1, fc.Len())
+	fc.Remove(barName)
+
+	require.Zero(t, fc.Len())
+	require.Zero(t, len(fc.removed))
 }
 
 func TestMultiFileInstances(t *testing.T) {
@@ -180,6 +187,7 @@ func TestMultiFileInstances(t *testing.T) {
 
 	fc.Clear()
 	require.Zero(t, fc.Len())
+	require.Zero(t, len(fc.removed))
 }
 
 func TestZeroSize(t *testing.T) {
@@ -213,4 +221,6 @@ func TestZeroSize(t *testing.T) {
 
 	require.NoError(t, fc.Close(file2))
 	require.Zero(t, len(fc.removed))
+
+	require.Zero(t, fc.Len())
 }

--- a/store/filecache/filecache_test.go
+++ b/store/filecache/filecache_test.go
@@ -80,6 +80,18 @@ func TestOpen(t *testing.T) {
 	require.Zero(t, fc.Len())
 	require.Zero(t, len(fc.removed))
 
+	// Check that double close returns error
+	fooFile, err = fc.Open(fooName)
+	require.NoError(t, err)
+	require.NoError(t, fc.Close(fooFile))
+	err = fc.Close(fooFile)
+	require.ErrorContains(t, err, os.ErrClosed.Error())
+
+	fc.Clear()
+
+	require.Zero(t, fc.Len())
+	require.Zero(t, len(fc.removed))
+
 	hits, misses, ln, cp := fc.Stats()
 	t.Logf("Cache stats: hits=%d misses=%d len=%d cap=%d", hits, misses, ln, cp)
 }

--- a/store/filecache/filecache_test.go
+++ b/store/filecache/filecache_test.go
@@ -29,13 +29,13 @@ func TestOpen(t *testing.T) {
 	barName := filepath.Join(tmp, "bar")
 	bazName := filepath.Join(tmp, "baz")
 
-	fooFile, err := fc.Open(fooName)
+	_, err := fc.Open(fooName)
 	require.NoError(t, err)
 
 	barFile, err := fc.Open(barName)
 	require.NoError(t, err)
 
-	fooFile, err = fc.Open(fooName)
+	fooFile, err := fc.Open(fooName)
 	require.NoError(t, err)
 
 	require.Zero(t, evictedCount)
@@ -51,6 +51,7 @@ func TestOpen(t *testing.T) {
 
 	barFile, err = fc.Open(barName)
 	require.NoError(t, err)
+	require.NoError(t, fc.Close(barFile))
 
 	require.Equal(t, 2, evictedCount)
 	require.Equal(t, fooName, evictedName)
@@ -61,8 +62,7 @@ func TestOpen(t *testing.T) {
 	err = fc.Close(fooFile)
 	require.ErrorContains(t, err, os.ErrClosed.Error())
 
-	err = fc.Remove(bazName)
-	require.NoError(t, err)
+	fc.Remove(bazName)
 
 	require.Equal(t, 3, evictedCount)
 	require.Equal(t, bazName, evictedName)
@@ -97,9 +97,9 @@ func TestMultiFileInstances(t *testing.T) {
 	// Incr reference count to 3.
 	fooFile, err := fc.Open(fooName)
 	require.NoError(t, err)
-	fooFile, err = fc.Open(fooName)
+	_, err = fc.Open(fooName)
 	require.NoError(t, err)
-	fooFile, err = fc.Open(fooName)
+	_, err = fc.Open(fooName)
 	require.NoError(t, err)
 
 	barFile, err := fc.Open(barName)
@@ -142,8 +142,8 @@ func TestMultiFileInstances(t *testing.T) {
 	// Remove the fooFileX from cache, without closing the file first. Since it
 	// still has a non-zero reference count, it is put into removed, along with
 	// the other instance of fooFile.
-	err = fc.Remove(fooName)
-	require.NoError(t, err)
+	fc.Remove(fooName)
+
 	// Check that there are two distinct files in removed, with different
 	// reference counts.
 	require.Equal(t, 2, len(fc.removed))

--- a/store/index/gc.go
+++ b/store/index/gc.go
@@ -45,6 +45,10 @@ func (index *Index) garbageCollector(interval, timeLimit time.Duration) {
 			gcDone = make(chan struct{})
 			go func() {
 				defer close(gcDone)
+				// Log cache stats.
+				hits, misses, cacheLen, cacheCap := index.fileCache.Stats()
+				log.Infow("File cache stats", "hits", hits, "misses", misses, "len", cacheLen, "cap", cacheCap)
+
 				log.Infow("GC started")
 				rmCount, freeCount, err := index.gc(ctx, timeLimit, freeSkip == 0)
 				switch err {

--- a/store/index/gc.go
+++ b/store/index/gc.go
@@ -143,18 +143,22 @@ func (index *Index) gc(ctx context.Context, timeLimit time.Duration, scanFree bo
 			}
 			return 0, 0, err
 		}
-		if stale && header.FirstFile == fileNum {
-			header.FirstFile++
-			err = writeHeader(index.headerPath, header)
-			if err != nil {
-				return 0, 0, err
+		if stale {
+			index.fileCache.Remove(indexPath)
+
+			// If this is first index file, then update header and remove file.
+			if header.FirstFile == fileNum {
+				header.FirstFile++
+				err = writeHeader(index.headerPath, header)
+				if err != nil {
+					return 0, 0, err
+				}
+				err = os.Remove(indexPath)
+				if err != nil {
+					return 0, 0, err
+				}
+				count++
 			}
-			// If updating index info ok, then remove stale index file.
-			err = os.Remove(indexPath)
-			if err != nil {
-				return 0, 0, err
-			}
-			count++
 		}
 
 		fileNum++
@@ -216,6 +220,8 @@ func (index *Index) truncateFreeFiles(ctx context.Context) (int, error) {
 		}
 
 		indexPath := indexFileName(basePath, fileNum)
+
+		index.fileCache.Remove(indexPath)
 
 		fi, err := os.Stat(indexPath)
 		if err != nil {

--- a/store/index/gc_test.go
+++ b/store/index/gc_test.go
@@ -26,7 +26,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, err)
 	defer primary.Close()
 
-	idx, err := Open(context.Background(), indexPath, primary, 24, 1024, 0, 0)
+	idx, err := Open(context.Background(), indexPath, primary, 24, 1024, 0, 0, testFCSize)
 	require.NoError(t, err)
 	defer idx.Close()
 
@@ -49,7 +49,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, RemoveSavedBuckets(indexPath))
 
 	// Open the index with the duplicated files.
-	idx, err = Open(context.Background(), indexPath, primary, 24, 1024, 0, 0)
+	idx, err = Open(context.Background(), indexPath, primary, 24, 1024, 0, 0, testFCSize)
 	require.NoError(t, err)
 	defer idx.Close()
 

--- a/store/index/index.go
+++ b/store/index/index.go
@@ -70,9 +70,6 @@ const (
 	// defaultMaxFileSize is the default size at which to start a new file.
 	defaultMaxFileSize = 1024 * 1024 * 1024
 
-	// Number of open files to keep in FileCache
-	fileCacheSize = 256
-
 	// sizePrefixSize is the number of bytes used for the size prefix of a
 	// record list.
 	sizePrefixSize = 4
@@ -158,7 +155,7 @@ type bucketPool map[BucketIndex][]byte
 //
 // Specifying 0 for indexSizeBits and maxFileSize results in using their
 // default values. A gcInterval of 0 disables garbage collection.
-func Open(ctx context.Context, path string, primary primary.PrimaryStorage, indexSizeBits uint8, maxFileSize uint32, gcInterval, gcTimeLimit time.Duration) (*Index, error) {
+func Open(ctx context.Context, path string, primary primary.PrimaryStorage, indexSizeBits uint8, maxFileSize uint32, gcInterval, gcTimeLimit time.Duration, fileCacheSize int) (*Index, error) {
 	var file *os.File
 	headerPath := filepath.Clean(path) + ".info"
 

--- a/store/index/index.go
+++ b/store/index/index.go
@@ -311,6 +311,10 @@ func (idx *Index) StorageSize() (int64, error) {
 	return size, nil
 }
 
+func (idx *Index) SetFileCacheSize(size int) {
+	idx.fileCache.SetCacheSize(size)
+}
+
 func scanIndexFile(ctx context.Context, basePath string, fileNum uint32, buckets Buckets, maxFileSize uint32) error {
 	indexPath := indexFileName(basePath, fileNum)
 

--- a/store/option.go
+++ b/store/option.go
@@ -7,6 +7,7 @@ import (
 )
 
 const (
+	defaultFileCacheSize = 512
 	defaultIndexSizeBits = uint8(24)
 	defaultIndexFileSize = uint32(1024 * 1024 * 1024)
 	defaultBurstRate     = 4 * 1024 * 1024
@@ -16,6 +17,7 @@ const (
 )
 
 type config struct {
+	fileCacheSize int
 	indexSizeBits uint8
 	indexFileSize uint32
 	syncInterval  time.Duration
@@ -30,6 +32,13 @@ type Option func(*config)
 func (c *config) apply(opts []Option) {
 	for _, opt := range opts {
 		opt(c)
+	}
+}
+
+// FileCacheSize is the number of open files the index file cache may keep.
+func FileCacheSize(size int) Option {
+	return func(c *config) {
+		c.fileCacheSize = size
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -321,6 +321,10 @@ func (s *Store) Remove(key []byte) (bool, error) {
 	return removed, nil
 }
 
+func (s *Store) SetFileCacheSize(size int) {
+	s.index.SetFileCacheSize(size)
+}
+
 func (s *Store) getPrimaryKeyData(blk types.Block, indexKey []byte) ([]byte, []byte, error) {
 	// Get the key and value stored in primary to see if it is the same (index
 	// only stores prefixes).

--- a/store/store.go
+++ b/store/store.go
@@ -45,6 +45,7 @@ type Store struct {
 // default values. A gcInterval of 0 disables garbage collection.
 func OpenStore(ctx context.Context, path string, primary primary.PrimaryStorage, immutable bool, options ...Option) (*Store, error) {
 	c := config{
+		fileCacheSize: defaultFileCacheSize,
 		indexSizeBits: defaultIndexSizeBits,
 		indexFileSize: defaultIndexFileSize,
 		syncInterval:  defaultSyncInterval,
@@ -54,7 +55,7 @@ func OpenStore(ctx context.Context, path string, primary primary.PrimaryStorage,
 	}
 	c.apply(options)
 
-	index, err := index.Open(ctx, path, primary, c.indexSizeBits, c.indexFileSize, c.gcInterval, c.gcTimeLimit)
+	index, err := index.Open(ctx, path, primary, c.indexSizeBits, c.indexFileSize, c.gcInterval, c.gcTimeLimit, c.fileCacheSize)
 	if err != nil {
 		return nil, err
 	}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.2.7"
+  "version": "v0.2.8"
 }


### PR DESCRIPTION
When reading values for multihashes, it is necessary to first open the index file that has the index record for the multihash's value list. When accessing many multihashes, this results in a large number of syscalls for opening and closing the index files. Statistically, more of the indexes reside in more recently created index files, so on average, only a subset of the total files is heavily accessed. By using an LRU cache to keep some number of these files open, many of the syscalls can be avoided.