### PR TITLE
Wait for flushes to catch up with incoming data

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ When both of the above conditions are true, an immediate flush is triggered and 
 #### Rate limiting
 Rate Limiting is accomplished by waiting for the triggered flush.
 
-If data continues to come in at this rate, then even continuous flushes will not keep up. During each flush, more data will accumulate in memory than was flushed. The next flush will handle that larger amount of data, but will build up even data more in memory, and so on. At some point, storethehash needs to temporarily stop accepting more data to allow flushes to catch up to what has built up in memory. The point this stop happens is after the rate-triggered flush is signaled, and activity resumes upon completion of the flush. If multiple goroutines trigger a flush due to incoming data date at the same time, they will only trigger a single flush and will all receive notification of its completion. 
+If data continues to come in at a rate faster than can be flushed, then even continuous flushes will not keep up. During each flush, more data will accumulate in memory than was flushed. The next flush will handle that larger amount of data, but will build up even data more in memory, and so on. At some point, storethehash needs to temporarily stop accepting more data to allow flushes to catch up to what has built up in memory. The is done with a _synchronous_ flush when the incoming data rate exceeds the flush rate and the amount of unflushed data is greater then the configured `BurstRate`. If multiple goroutines trigger a synchronous flush while one is already executing, they will wait on the flush already in progress and will all receive notification of its completion. 
 
 ## Trade-offs
 

--- a/store/option.go
+++ b/store/option.go
@@ -74,8 +74,8 @@ func SyncInterval(syncInterval time.Duration) Option {
 	}
 }
 
-// BurstRate specifies how much unwritten data can accumulate before causing
-// data to be flushed to disk.
+// BurstRate specifies how much unwritten data can accumulate, at a rate faster
+// than can be flushed, before causing data to be flushed to disk.
 func BurstRate(burstRate uint64) Option {
 	return func(c *config) {
 		c.burstRate = types.Work(burstRate)

--- a/store/option.go
+++ b/store/option.go
@@ -74,8 +74,8 @@ func SyncInterval(syncInterval time.Duration) Option {
 	}
 }
 
-// BurstRate specifies how much unwritten data can accumulate, at a rate faster
-// than can be flushed, before causing data to be flushed to disk.
+// BurstRate specifies how much data can accumulate in memory, at a rate faster
+// than can be flushed, before causing a synchronous flush.
 func BurstRate(burstRate uint64) Option {
 	return func(c *config) {
 		c.burstRate = types.Work(burstRate)

--- a/store/primary/multihash/gc_test.go
+++ b/store/primary/multihash/gc_test.go
@@ -15,11 +15,12 @@ import (
 )
 
 func TestGC(t *testing.T) {
+	const lowUsePercent = 74
+
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	indexPath := filepath.Join(tempDir, "storethehash.index")
 	dataPath := filepath.Join(tempDir, "storethehash.data")
-
 	t.Logf("Creating store in directory %s\n", tempDir)
 
 	store, err := store.OpenStore(ctx, store.MultihashPrimary, dataPath, indexPath, false, store.GCInterval(time.Hour), store.PrimaryFileSize(1024), store.IndexFileSize(10240), store.SyncInterval(time.Minute))
@@ -68,7 +69,7 @@ func TestGC(t *testing.T) {
 	primaryIface := store.Primary()
 	primary := primaryIface.(*mhprimary.MultihashPrimary)
 
-	fileCount, err := primary.GC(ctx)
+	fileCount, err := primary.GC(ctx, lowUsePercent)
 	require.NoError(t, err)
 	require.Equal(t, 1, fileCount)
 
@@ -79,7 +80,7 @@ func TestGC(t *testing.T) {
 	require.FileExists(t, primary2)
 
 	t.Logf("Running primary GC with not additional removals")
-	fileCount, err = primary.GC(ctx)
+	fileCount, err = primary.GC(ctx, lowUsePercent)
 	require.NoError(t, err)
 	require.Zero(t, fileCount)
 
@@ -98,7 +99,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Running primary GC")
-	fileCount, err = primary.GC(ctx)
+	fileCount, err = primary.GC(ctx, lowUsePercent)
 	require.NoError(t, err)
 	require.Zero(t, fileCount)
 
@@ -119,7 +120,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Running primary GC on low-use file to evaporate remaining record")
-	fileCount, err = primary.GC(ctx)
+	fileCount, err = primary.GC(ctx, lowUsePercent)
 	require.NoError(t, err)
 	require.Zero(t, fileCount)
 
@@ -131,7 +132,7 @@ func TestGC(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf("Running primary GC on low-use file to remove file")
-	fileCount, err = primary.GC(ctx)
+	fileCount, err = primary.GC(ctx, lowUsePercent)
 	require.NoError(t, err)
 	require.Equal(t, 1, fileCount)
 

--- a/store/primary/multihash/multihash.go
+++ b/store/primary/multihash/multihash.go
@@ -168,7 +168,7 @@ func (mp *MultihashPrimary) StartGC(freeList *freelist.FreeList, interval, timeL
 	mp.gc = newGC(mp, freeList, interval, timeLimit, updateIndex)
 }
 
-func (mp *MultihashPrimary) GC(ctx context.Context) (int, error) {
+func (mp *MultihashPrimary) GC(ctx context.Context, lowUsePercent int64) (int, error) {
 	mp.gcMutex.Lock()
 	gc := mp.gc
 	mp.gcMutex.Unlock()
@@ -177,7 +177,7 @@ func (mp *MultihashPrimary) GC(ctx context.Context) (int, error) {
 		return 0, errors.New("gc disabled")
 	}
 
-	return gc.gc(ctx, 0)
+	return gc.gc(ctx, 0, lowUsePercent)
 }
 
 func (cp *MultihashPrimary) FileSize() uint32 {

--- a/store/store.go
+++ b/store/store.go
@@ -437,14 +437,13 @@ func (s *Store) flushTick() {
 	// is necessary to wait for the flush, otherwise more work could continue
 	// to come in and be stored in memory faster that flushes could handle it,
 	// leading to memory exhaustion.
-	var flushNotice <-chan struct{}
 	if inRate > flushRate {
 		// Get a channel that broadcasts next flush completion.
 		s.rateLk.Lock()
 		if s.flushNotice == nil {
 			s.flushNotice = make(chan struct{})
 		}
-		flushNotice = s.flushNotice
+		flushNotice := s.flushNotice
 		s.rateLk.Unlock()
 
 		// Trigger flush now, non-blocking.

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.0"
+  "version": "v0.3.1"
 }


### PR DESCRIPTION
If the rate of incoming work exceeds the rate that work can be flushed at, and there is enough work to be concerned about, then trigger an immediate flush and wait for the flush to complete. Since data continues to accumulate in memory during a flush, it is necessary to wait for the flush during this condition, otherwise, more work could continue to come in and be stored in memory faster than flushes could handle it (even with continuous flushes), causing memory exhaustion.

- Update README to describe flush and rate limiting design.

Fixes #9
