### PR TITLE
Continue upgrade after error reading freelist

### DIFF
--- a/store/primary/multihash/upgrade.go
+++ b/store/primary/multihash/upgrade.go
@@ -265,10 +265,11 @@ func applyFreeList(ctx context.Context, freeList *freelist.FreeList, filePath st
 		for {
 			free, err := flIter.Next()
 			if err != nil {
-				if err == io.EOF {
-					break
+				// Done reading freelist; log if error.
+				if err != io.EOF {
+					log.Errorw("error reading freelist", "err", err)
 				}
-				return fmt.Errorf("error reading freelist: %w", err)
+				break
 			}
 
 			offset := int64(free.Offset)

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.1"
+  "version": "v0.3.2"
 }


### PR DESCRIPTION
If the freelist is corrupted an cannot be read, so not stop upgrade, but stop processing the freelist and continue on.