### PR TITLE
Automatically translate index if bit size is different from existing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ When a new key is inserted, the first few bits (24 in this example) will be used
 
 ### Index
 
-The index is an append-only log that maps keys to offsets in the primary storage. Updates are always appended, there are no in-place updates. The index consists of so-called record lists. There is one record list per bucket. Such a list contains all keys that are mapped to one specific bucket.
+The index is an append-only log that maps keys to offsets in the primary storage. Updates are always appended, there are no in-place updates. The index consists of so-called record lists. There is one record list per bucket. Such a list contains all keys that are mapped to one specific bucket. If storethehash is restarted with a different number of index bits that it previously had, the index files are automatically migrated to the new size.
 
-The index is split across multiple files on disk. By default, each of these files may reach a maximum size of approximately 1GiB. When all record lists in an index file are no longer referenced by any file offsets in the Bucket, that index file can be deleted.  These unused index files are removed, in order, by the index garbage collector.  
+The index is split across multiple files on disk. By default, each of these files may reach a maximum size of approximately 1GiB, where the last record in that file must start before the 1GiB limit. The index has garbage collection that truncates deleted records from the end of index files and removes empty index files.
 
 #### Record list
 
@@ -45,6 +45,8 @@ There are various implementations of a primary storage provided.
 - An in-memory storage implementation
 - An implementation that is [CID](https://github.com/multiformats/cid/) aware.
 - An implementation that is [Multihash](https://github.com/multiformats/multihash) aware.
+
+The multihash implementation has garbage collection that allows storage space to be recovered from deleted data.
 
 ### Freelist
 

--- a/store/index/index.go
+++ b/store/index/index.go
@@ -130,24 +130,57 @@ type bucketPool map[BucketIndex][]byte
 // no existing index at the specified path. If there is an older version index,
 // then it is automatically upgraded.
 //
-// Specifying 0 for indexSizeBits and maxFileSize results in using their
-// default values. A gcInterval of 0 disables garbage collection.
+// Specifying 0 for indexSizeBits and maxFileSize results in using the values
+// of the existing index, or default values if no index exists. A gcInterval of
+// 0 disables garbage collection.
 func Open(ctx context.Context, path string, primary primary.PrimaryStorage, indexSizeBits uint8, maxFileSize uint32, gcInterval, gcTimeLimit time.Duration, fileCache *filecache.FileCache) (*Index, error) {
 	var file *os.File
-	headerPath := filepath.Clean(path) + ".info"
+	headerPath := headerName(path)
 
-	if indexSizeBits == 0 {
-		indexSizeBits = defaultIndexSizeBits
+	if indexSizeBits != 0 && (indexSizeBits > 31 || indexSizeBits < 8) {
+		return nil, fmt.Errorf("indexSizeBits must be between 8 and 31, default is %d", defaultIndexSizeBits)
 	}
-	if maxFileSize == 0 {
-		maxFileSize = defaultMaxFileSize
-	} else if maxFileSize > defaultMaxFileSize {
+	if maxFileSize > defaultMaxFileSize {
 		return nil, fmt.Errorf("maximum file size cannot exceed %d", defaultMaxFileSize)
 	}
 
-	err := upgradeIndex(ctx, path, headerPath, maxFileSize)
+	upgradeFileSize := maxFileSize
+	if upgradeFileSize == 0 {
+		upgradeFileSize = defaultMaxFileSize
+	}
+	err := upgradeIndex(ctx, path, headerPath, upgradeFileSize)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not upgrade index: %w", err)
+	}
+
+	var existingHeader bool
+	header, err := readHeader(headerPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		if indexSizeBits == 0 {
+			indexSizeBits = defaultIndexSizeBits
+		}
+		if maxFileSize == 0 {
+			maxFileSize = defaultMaxFileSize
+		}
+		header = newHeader(indexSizeBits, maxFileSize)
+		mp, ok := primary.(*mhprimary.MultihashPrimary)
+		if ok {
+			header.PrimaryFileSize = mp.FileSize()
+		}
+		if err = writeHeader(headerPath, header); err != nil {
+			return nil, err
+		}
+	} else {
+		existingHeader = true
+		if indexSizeBits == 0 {
+			indexSizeBits = header.BucketsBits
+		}
+		if maxFileSize == 0 {
+			maxFileSize = header.MaxFileSize
+		}
 	}
 
 	buckets, err := NewBuckets(indexSizeBits)
@@ -157,17 +190,7 @@ func Open(ctx context.Context, path string, primary primary.PrimaryStorage, inde
 
 	var rmPool bucketPool
 	var lastIndexNum uint32
-	header, err := readHeader(headerPath)
-	if os.IsNotExist(err) {
-		header = newHeader(indexSizeBits, maxFileSize)
-		if err = writeHeader(headerPath, header); err != nil {
-			return nil, err
-		}
-	} else {
-		if err != nil {
-			return nil, err
-		}
-
+	if existingHeader {
 		if header.BucketsBits != indexSizeBits {
 			return nil, types.ErrIndexWrongBitSize{header.BucketsBits, indexSizeBits}
 		}
@@ -1062,7 +1085,7 @@ func (iter *RawIterator) Close() error {
 // On each iteration it returns the position of the record within the index
 // together with the raw record list data.
 type Iterator struct {
-	// bucket is the next bucket to iterate.
+	// bucketIndex is the next bucket to iterate.
 	bucketIndex BucketIndex
 	// index is the Index being iterated.
 	index  *Index
@@ -1073,6 +1096,11 @@ func (idx *Index) NewIterator() *Iterator {
 	return &Iterator{
 		index: idx,
 	}
+}
+
+// Progress returns the percentage of buckets iterated.
+func (iter *Iterator) Progress() float64 {
+	return 100.0 * float64(iter.bucketIndex) / float64(len(iter.index.buckets))
 }
 
 func (iter *Iterator) Next() (Record, bool, error) {
@@ -1396,4 +1424,82 @@ func remapIndex(ctx context.Context, mp *mhprimary.MultihashPrimary, buckets Buc
 
 	log.Infow("Remapped primary offsets", "fileCount", fileCount, "recordCount", recordCount)
 	return rmPool, nil
+}
+
+func headerName(basePath string) string {
+	return filepath.Clean(basePath) + ".info"
+}
+
+type fileIter struct {
+	basePath string
+	fileNum  uint32
+}
+
+func newFileIter(basePath string) (*fileIter, error) {
+	header, err := readHeader(headerName(basePath))
+	if err != nil {
+		return nil, err
+	}
+	return &fileIter{
+		basePath: basePath,
+		fileNum:  header.FirstFile,
+	}, nil
+}
+
+// next returns the name of the next index file. Returns io.EOF if there are no
+// more index files.
+func (fi *fileIter) next() (string, error) {
+	_, err := os.Stat(indexFileName(fi.basePath, fi.fileNum))
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = io.EOF
+		}
+		return "", err
+	}
+	fileName := indexFileName(fi.basePath, fi.fileNum)
+	fi.fileNum++
+
+	return fileName, nil
+}
+
+func MoveFiles(indexPath, newDir string) error {
+	err := os.MkdirAll(newDir, 0755)
+	if err != nil {
+		return err
+	}
+
+	fileIter, err := newFileIter(indexPath)
+	if err != nil {
+		return err
+	}
+	for {
+		fileName, err := fileIter.next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		newPath := filepath.Join(newDir, filepath.Base(fileName))
+		if err = os.Rename(fileName, newPath); err != nil {
+			return err
+		}
+	}
+
+	headerPath := headerName(indexPath)
+	newPath := filepath.Join(newDir, filepath.Base(headerPath))
+	if err = os.Rename(headerPath, newPath); err != nil {
+		return err
+	}
+
+	bucketsPath := savedBucketsName(indexPath)
+	_, err = os.Stat(bucketsPath)
+	if !os.IsNotExist(err) {
+		newPath = filepath.Join(newDir, filepath.Base(bucketsPath))
+		if err = os.Rename(bucketsPath, newPath); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/store/index/index_test.go
+++ b/store/index/index_test.go
@@ -113,6 +113,10 @@ func TestIndexPutSingleKey(t *testing.T) {
 	err = i.Close()
 	require.NoError(t, err)
 
+	// Test double close.
+	err = i.Close()
+	require.NoError(t, err)
+
 	// Skip header
 	iter := NewRawIterator(i.basePath, i.fileNum)
 	defer iter.Close()

--- a/store/index/upgrade.go
+++ b/store/index/upgrade.go
@@ -15,6 +15,7 @@ func upgradeIndex(ctx context.Context, name, headerPath string, maxFileSize uint
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
+
 	inFile, err := os.Open(name)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -26,7 +27,7 @@ func upgradeIndex(ctx context.Context, name, headerPath string, maxFileSize uint
 
 	version, bucketBits, _, err := readOldHeader(inFile)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot read old index header from %s: %w", name, err)
 	}
 	if version != 2 {
 		return fmt.Errorf("cannot convert unknown header version: %d", version)

--- a/store/primary/multihash/multihash.go
+++ b/store/primary/multihash/multihash.go
@@ -157,11 +157,15 @@ func Open(path string, freeList *freelist.FreeList, fileCache *filecache.FileCac
 }
 
 func (mp *MultihashPrimary) StartGC(freeList *freelist.FreeList, interval, timeLimit time.Duration, updateIndex UpdateIndexFunc) {
+	if freeList == nil || interval == 0 {
+		return
+	}
+
 	mp.gcMutex.Lock()
 	defer mp.gcMutex.Unlock()
 
-	// If GC already started or no free list, then do nothing.
-	if mp.gc != nil || freeList == nil {
+	// If GC already started, then do nothing.
+	if mp.gc != nil {
 		return
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -274,13 +274,11 @@ func (s *Store) run() {
 // files.
 func (s *Store) Close() error {
 	s.stateLk.Lock()
-	open := s.open
-	s.open = false
-
-	if !open {
+	if !s.open {
 		s.stateLk.Unlock()
 		return nil
 	}
+	s.open = false
 
 	running := s.running
 	s.running = false

--- a/store/store.go
+++ b/store/store.go
@@ -195,10 +195,10 @@ func translateIndex(ctx context.Context, indexPath string, primary primary.Prima
 
 	log.Info("Replacing old index files with new")
 	if err = newIndex.Close(); err != nil {
-		return fmt.Errorf("Error closing new index: %w", err)
+		return fmt.Errorf("error closing new index: %w", err)
 	}
 	if err = oldIndex.Close(); err != nil {
-		return fmt.Errorf("Error closing old index: %w", err)
+		return fmt.Errorf("error closing old index: %w", err)
 	}
 
 	// Create a temp directory for the old index files and move them there.

--- a/store/store.go
+++ b/store/store.go
@@ -130,7 +130,7 @@ func OpenStore(ctx context.Context, primaryType string, dataPath, indexPath stri
 }
 
 func translateIndex(ctx context.Context, indexPath string, primary primary.PrimaryStorage, indexSizeBits uint8, indexFileSize uint32) error {
-	const progressLogInterval = time.Millisecond //5 * time.Second
+	const progressLogInterval = 5 * time.Second
 
 	log.Infof("Translating index to %d bit prefix", indexSizeBits)
 
@@ -191,7 +191,7 @@ func translateIndex(ctx context.Context, indexPath string, primary primary.Prima
 	}
 	ticker.Stop()
 
-	log.Infof("Translated %d records", count)
+	log.Infof("Translated %d index records", count)
 
 	log.Info("Replacing old index files with new")
 	if err = newIndex.Close(); err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -135,7 +135,6 @@ func translateIndex(ctx context.Context, indexPath string, primary primary.Prima
 	log.Infof("Translating index to %d bit prefix", indexSizeBits)
 
 	oldFileCache := filecache.New(64)
-	defer oldFileCache.Clear()
 	log.Info("Reading old index")
 	oldIndex, err := index.Open(ctx, indexPath, primary, 0, indexFileSize, 0, 0, oldFileCache)
 	if err != nil {
@@ -152,7 +151,6 @@ func translateIndex(ctx context.Context, indexPath string, primary primary.Prima
 
 	newIndexPath := filepath.Join(indexTmp, filepath.Base(indexPath))
 	newFileCache := filecache.New(64)
-	defer newFileCache.Clear()
 	newIndex, err := index.Open(ctx, newIndexPath, primary, indexSizeBits, indexFileSize, 0, 0, newFileCache)
 	if err != nil {
 		return fmt.Errorf("cannot open new index: %w", err)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -287,8 +287,8 @@ func TestTranslate(t *testing.T) {
 	indexPath := filepath.Join(tempDir, "storethehash.index")
 	dataPath := filepath.Join(tempDir, "storethehash.data")
 
-	t.Logf("Createing store with 24-bit index")
-	s, err := store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(24), store.GCInterval(0))
+	t.Logf("Createing store with 16-bit index")
+	s, err := store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(16), store.GCInterval(0))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, s.Close()) })
 
@@ -306,8 +306,8 @@ func TestTranslate(t *testing.T) {
 	require.NoError(t, s.Close())
 
 	// Translate to 26 bits
-	t.Logf("Translating store index from 24-bit to 26-bit")
-	s, err = store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(26), store.GCInterval(0))
+	t.Logf("Translating store index from 16-bit to 24-bit")
+	s, err = store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(24), store.GCInterval(0))
 	require.NoError(t, err)
 
 	// Check that blocks still exist.
@@ -326,7 +326,7 @@ func TestTranslate(t *testing.T) {
 	require.NoError(t, s.Close())
 
 	// Translate back to 24 bits.
-	t.Logf("Translating store index from 26-bit to 16-bit")
+	t.Logf("Translating store index from 24-bit to 16-bit")
 	s, err = store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(16), store.GCInterval(0))
 	require.NoError(t, err)
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -286,25 +286,26 @@ func TestTranslate(t *testing.T) {
 
 	indexPath := filepath.Join(tempDir, "storethehash.index")
 	dataPath := filepath.Join(tempDir, "storethehash.data")
+
+	t.Logf("Createing store with 24-bit index")
 	s, err := store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(24), store.GCInterval(0))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, s.Close()) })
 
+	// Store blocks.
 	blks := testutil.GenerateBlocksOfSize(5, 100)
-
-	t.Logf("Createing store with 24-bit index")
 	for i := range blks {
 		err = s.Put(blks[i].Cid().Hash(), blks[i].RawData())
 		require.NoError(t, err)
 	}
-
+	// REmove on block.
 	removed, err := s.Remove(blks[0].Cid().Hash())
 	require.NoError(t, err)
 	require.True(t, removed)
 
 	require.NoError(t, s.Close())
 
-	// Translate to 30 bits
+	// Translate to 26 bits
 	t.Logf("Translating store index from 24-bit to 26-bit")
 	s, err = store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(26), store.GCInterval(0))
 	require.NoError(t, err)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -288,63 +288,65 @@ func TestTranslate(t *testing.T) {
 	dataPath := filepath.Join(tempDir, "storethehash.data")
 
 	t.Logf("Createing store with 16-bit index")
-	s, err := store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(16), store.GCInterval(0))
+	s1, err := store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(16), store.GCInterval(0))
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	t.Cleanup(func() { require.NoError(t, s1.Close()) })
 
 	// Store blocks.
 	blks := testutil.GenerateBlocksOfSize(5, 100)
 	for i := range blks {
-		err = s.Put(blks[i].Cid().Hash(), blks[i].RawData())
+		err = s1.Put(blks[i].Cid().Hash(), blks[i].RawData())
 		require.NoError(t, err)
 	}
 	// REmove on block.
-	removed, err := s.Remove(blks[0].Cid().Hash())
+	removed, err := s1.Remove(blks[0].Cid().Hash())
 	require.NoError(t, err)
 	require.True(t, removed)
 
-	require.NoError(t, s.Close())
+	require.NoError(t, s1.Close())
 
 	// Translate to 26 bits
 	t.Logf("Translating store index from 16-bit to 24-bit")
-	s, err = store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(24), store.GCInterval(0))
+	s2, err := store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(24), store.GCInterval(0))
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s2.Close()) })
 
 	// Check that blocks still exist.
 	for i := 1; i < len(blks); i++ {
-		value, found, err := s.Get(blks[i].Cid().Hash())
+		value, found, err := s2.Get(blks[i].Cid().Hash())
 		require.NoError(t, err)
 		require.True(t, found)
 		require.Equal(t, value, blks[i].RawData())
 	}
 
 	// Check that removed block was not found.
-	_, found, err := s.Get(blks[0].Cid().Hash())
+	_, found, err := s2.Get(blks[0].Cid().Hash())
 	require.NoError(t, err)
 	require.False(t, found)
 
-	require.NoError(t, s.Close())
+	require.NoError(t, s2.Close())
 
 	// Translate back to 24 bits.
 	t.Logf("Translating store index from 24-bit to 16-bit")
-	s, err = store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(16), store.GCInterval(0))
+	s3, err := store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(16), store.GCInterval(0))
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s3.Close()) })
 
 	// Check that blocks still exist.
 	for i := 1; i < len(blks); i++ {
-		value, found, err := s.Get(blks[i].Cid().Hash())
+		value, found, err := s3.Get(blks[i].Cid().Hash())
 		require.NoError(t, err)
 		require.True(t, found)
 		require.Equal(t, value, blks[i].RawData())
 	}
 
 	// Check that removed block was not found.
-	_, found, err = s.Get(blks[0].Cid().Hash())
+	_, found, err = s3.Get(blks[0].Cid().Hash())
 	require.NoError(t, err)
 	require.False(t, found)
 
-	require.NoError(t, s.Close())
+	require.NoError(t, s3.Close())
 
 	// Check that double close of store is ok.
-	require.NoError(t, s.Close())
+	require.NoError(t, s3.Close())
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -305,8 +305,8 @@ func TestTranslate(t *testing.T) {
 	require.NoError(t, s.Close())
 
 	// Translate to 30 bits
-	t.Logf("Translating store index from 24-bit to 30-bit")
-	s, err = store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(30), store.GCInterval(0))
+	t.Logf("Translating store index from 24-bit to 26-bit")
+	s, err = store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(26), store.GCInterval(0))
 	require.NoError(t, err)
 
 	// Check that blocks still exist.
@@ -325,7 +325,7 @@ func TestTranslate(t *testing.T) {
 	require.NoError(t, s.Close())
 
 	// Translate back to 24 bits.
-	t.Logf("Translating store index from 30-bit to 16-bit")
+	t.Logf("Translating store index from 26-bit to 16-bit")
 	s, err = store.OpenStore(context.Background(), store.MultihashPrimary, dataPath, indexPath, false, store.IndexBitSize(16), store.GCInterval(0))
 	require.NoError(t, err)
 

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.4"
+  "version": "v0.3.5"
 }


### PR DESCRIPTION
After any upgrades have been performed, if the requested index size bits value is different from the existing size bits value, then rewrite all the index records to a new index with the requested size. This migrates to and from any legal index sizes (between 8 and 31 bits).

Other changes:
- Specifying 0 for the `indexSizeBits` and the `maxFileSize` will use the existing value if an index already exists, otherwise it uses the default.
- Better error reporting
- Set the primary file size in the index header when creating a new index

This PR replaces #62, and is far more efficient because it does not require any processing of the primary or freelist.
 
Fixes #78

Since only the index is translated, the additional storage required is only as much space as the index takes. This is generally about 30% of the total storage size. 