### PR TITLE
Fix an error when closing a file in the file cache

### DIFF
--- a/store/filecache/filecache_test.go
+++ b/store/filecache/filecache_test.go
@@ -288,6 +288,7 @@ func TestFuzz(t *testing.T) {
 
 	require.Zero(t, len(fc.removed))
 	fc.Clear()
+	require.Zero(t, fc.Len())
 	require.Zero(t, len(fc.cache))
 	require.Zero(t, len(fc.removed))
 }
@@ -306,6 +307,8 @@ func TestEvict(t *testing.T) {
 		evictions++
 	}
 	fc := NewOpenFile(capacity, os.O_CREATE|os.O_RDWR, 0644)
+	t.Cleanup(func() { fc.Clear() })
+
 	fc.SetOnEvicted(onEvicted)
 
 	tmp := t.TempDir()


### PR DESCRIPTION
A "file already closed" was happening in the following situation:

Open a file to get 1st *File, let it be evicted, open that same file again to get 2nd *File, then close both 1st and 2nd *File. The first Close was closing the one in the cache, when it should have been closing the evicted but still open file. The second close that tries to close the file in the cache and, result in a "file already closed" error.

This PR ensures that the first close closes the evicted *File, not the one in cache.

Fixed https://github.com/filecoin-project/storetheindex/issues/931
